### PR TITLE
Add support for ESM imports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@
 /index.d.ts
 /test/*.d.ts
 /test/*.js
+node_modules
+lib

--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,4 @@
 /test/*.d.ts
 /test/*.js
 node_modules
-lib
+lib/**/**.js

--- a/lib/esm/package.json
+++ b/lib/esm/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,48 @@
   "version": "1.1.0",
   "description": "Secure, audited & minimal implementation of BIP39 mnemonic phrases",
   "main": "index.js",
+  "exports": {
+    ".": {
+      "import": "./lib/esm/index.js",
+      "default": "./lib/esm/index.js"
+    },
+    "./wordlists/czech": {
+      "import": "./lib/esm/wordlists/czech.js",
+      "default": "./lib/esm/wordlists/czech.js"
+    },
+    "./wordlists/english": {
+      "import": "./lib/esm/wordlists/english.js",
+      "default": "./lib/esm/wordlists/english.js"
+    },
+    "./wordlists/french": {
+      "import": "./lib/esm/wordlists/french.js",
+      "default": "./lib/esm/wordlists/french.js"
+    },
+    "./wordlists/italian": {
+      "import": "./lib/esm/wordlists/italian.js",
+      "default": "./lib/esm/wordlists/italian.js"
+    },
+    "./wordlists/japanese": {
+      "import": "./lib/esm/wordlists/japanese.js",
+      "default": "./lib/esm/wordlists/japanese.js"
+    },
+    "./wordlists/korean": {
+      "import": "./lib/esm/wordlists/korean.js",
+      "default": "./lib/esm/wordlists/korean.js"
+    },
+    "./wordlists/simplified-chinese": {
+      "import": "./lib/esm/wordlists/simplified-chinese.js",
+      "default": "./lib/esm/wordlists/simplified-chinese.js"
+    },
+    "./wordlists/spanish": {
+      "import": "./lib/esm/wordlists/spanish.js",
+      "default": "./lib/esm/wordlists/spanish.js"
+    },
+    "./wordlists/traditional-chinese": {
+      "import": "./lib/esm/wordlists/traditional-chinese.js",
+      "default": "./lib/esm/wordlists/traditional-chinese.js"
+    }
+  },
   "files": [
     "index.js",
     "index.d.ts",
@@ -38,7 +80,7 @@
   ],
   "license": "MIT",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && tsc -p tsconfig.esm.json",
     "lint": "prettier --check 'src/**/*.ts' 'test/*.test.ts'",
     "format": "prettier --write 'src/**/*.ts' 'test/*.test.ts'",
     "test": "cd test && tsc && mocha bip39.test.js"

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "outDir": "lib/esm",
+    "target": "es2020",
+    "module": "es6",
+    "moduleResolution": "node16",
+    "noUnusedLocals": true,
+    "baseUrl": ".",
+  },
+  "include": [
+    "src"
+  ],
+  "exclude": [
+    "node_modules",
+    "lib",
+  ],
+}


### PR DESCRIPTION
Hi! Thanks for your great work! 🙏

I'm using a library that has a dependency on this in my app, and was struggling with a `Cannot use import statement outside a module` error message. I believe this is due to the lack of ESM support :)

<img width="703" alt="CleanShot 2023-01-08 at 21 32 14@2x" src="https://user-images.githubusercontent.com/2598660/211220162-b39724f1-f316-4e1b-b90f-b08cac84a3ae.png">

I noticed that you've added ESM in your other libraries (like `noble-curves` and `nobke-hashes`) through a separate `tsconfig` file, so I've tried to follow the same convention in this PR!