### PR TITLE
chore: add `"sideEffects": false` to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "src/index.ts"
   ],
   "types": "index.d.ts",
+  "sideEffects": false,
   "dependencies": {
     "@noble/hashes": "~1.4.0",
     "@scure/base": "~1.1.6"


### PR DESCRIPTION
Adds `"sideEffects": false` to package.json for maximum tree-shakability.

Without `"sideEffects"` switched off build systems aren't able to properly eliminate dead code (e.g. Next.js) and could still contain unused code, [like wordlists](https://github.com/wevm/viem/discussions/2069), even if they are unused.

More info: https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free