### PR TITLE
feat: add pretest script to ensure build runs before tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "build:release": "npx jsbt esbuild test/build",
     "lint": "prettier --check 'src/**/*.ts' 'test/*.test.ts' 'test/scripts/*.js'",
     "format": "prettier --write 'src/**/*.ts' 'test/*.test.ts' 'test/scripts/*.js'",
+    "pretest": "npm run build",
     "test": "node --experimental-strip-types --no-warnings test/index.ts",
     "test:bun": "bun test/index.ts",
     "test:deno": "deno --allow-env --allow-read test/index.js",


### PR DESCRIPTION
## Problem

When running tests, we need to ensure the project is built first, otherwise tests may fail due to missing compiled files.

## Solution

Added a `pretest` npm script that automatically runs `npm run build` before `npm run test` executes. This leverages npm's hook system to ensure the project is always built before testing.

## Testing

1. Removed build files
2. Ran `npm run test` directly
3. Verified that the build automatically executed and all tests passed