### PR TITLE
Add Uint8Array support

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,15 @@ function validateMnemonic(mnemonic: string, wordlist: string[]): boolean;
 function mnemonicToSeed(mnemonic: string, passphrase?: string): Promise<Uint8Array>;
 function mnemonicToSeedSync(mnemonic: string, passphrase?: string): Uint8Array;
 function mnemonicToSeedWebcrypto(mnemonic: string, passphrase?: string): Promise<Uint8Array>;
+
+// Byte-oriented API
+function generateEntropyBytes(strength?: number): Uint8Array;
+function entropyToMnemonicBytes(entropy: Uint8Array, wordlist: string[]): Uint8Array;
+function mnemonicToEntropyFromBytes(mnemonic: Uint8Array, wordlist: string[]): Uint8Array;
+function validateMnemonicFromBytes(mnemonic: Uint8Array, wordlist: string[]): boolean;
+function entropyToSeedSyncFromBytes(entropy: Uint8Array, wordlist: string[], passphrase?: Uint8Array): Uint8Array;
+function mnemonicToSeedSyncFromBytes(mnemonic: Uint8Array, passphrase?: Uint8Array): Uint8Array;
+function mnemonicToSeedFromBytes(mnemonic: Uint8Array, passphrase?: Uint8Array): Promise<Uint8Array>;
 ```
 
 All wordlists (**warning: non-english wordlists are officially discouraged by bip39**):

--- a/README.md
+++ b/README.md
@@ -63,11 +63,22 @@ bip39.validateMnemonic(mn256, wordlist);
 const seed1 = await bip39.mnemonicToSeed(mn, 'password');
 const seed2 = bip39.mnemonicToSeedSync(mn, 'password');
 const seed3 = await bip39.mnemonicToSeedWebcrypto(mn, 'password'); // Native, WebCrypto version.
+
+// Byte-oriented API (for memory security)
+const entropy = bip39.generateEntropyBytes(128); // 16 bytes
+const mnBytes = bip39.entropyToMnemonicBytes(entropy, wordlist); // Uint8Array of UTF-8 words
+
+// Explicitly zero memory after use
+const seed4 = await bip39.mnemonicToSeedFromBytes(mnBytes, new Uint8Array([1, 2, 3]));
+const seed5 = await bip39.mnemonicToSeedFromBytesWebcrypto(mnBytes); // Faster native version
+mnBytes.fill(0); 
+entropy.fill(0);
 ```
 
 This submodule contains the word lists defined by BIP39 for Czech, English, French, Italian, Japanese, Korean, Portuguese, Simplified and Traditional Chinese, and Spanish. These are not imported by default, as that would increase bundle sizes too much. Instead, you should import and use them explicitly.
 
 ```typescript
+// String-oriented API
 function generateMnemonic(wordlist: string[], strength?: number): string;
 function mnemonicToEntropy(mnemonic: string, wordlist: string[]): Uint8Array;
 function entropyToMnemonic(entropy: Uint8Array, wordlist: string[]): string;
@@ -84,6 +95,7 @@ function validateMnemonicFromBytes(mnemonic: Uint8Array, wordlist: string[]): bo
 function entropyToSeedSyncFromBytes(entropy: Uint8Array, wordlist: string[], passphrase?: Uint8Array): Uint8Array;
 function mnemonicToSeedSyncFromBytes(mnemonic: Uint8Array, passphrase?: Uint8Array): Uint8Array;
 function mnemonicToSeedFromBytes(mnemonic: Uint8Array, passphrase?: Uint8Array): Promise<Uint8Array>;
+function mnemonicToSeedFromBytesWebcrypto(mnemonic: Uint8Array, passphrase?: Uint8Array): Promise<Uint8Array>;
 ```
 
 All wordlists (**warning: non-english wordlists are officially discouraged by bip39**):

--- a/src/index.ts
+++ b/src/index.ts
@@ -236,3 +236,281 @@ export function mnemonicToSeedWebcrypto(
     dkLen: 64,
   }) as Promise<TRet<Uint8Array>>;
 }
+
+/**
+ * Byte-oriented support
+ *
+ * The following functions provide byte-oriented BIP-39 helpers for applications
+ * that need explicit control over the lifetime of sensitive data.
+ *
+ * Uint8Array values can be overwritten after use, while JavaScript strings are
+ * immutable and cannot be reliably zeroed once created in the heap.
+ *
+ * Some non-ASCII code paths may still create temporary strings internally for
+ * Unicode normalization and wordlist handling, but the external API lets the
+ * caller keep secrets in mutable buffers and zero them when they are no longer needed.
+ */
+
+const isASCII = (data: Uint8Array) => {
+  for (let i = 0; i < data.length; i++) if (data[i] > 127) return false;
+  return true;
+};
+
+const WORD_SEPARATOR = 0x20;
+const MNEMONIC_SALT_PREFIX = new Uint8Array([109, 110, 101, 109, 111, 110, 105, 99]); // "mnemonic"
+const JAPANESE_MNEMONIC_SEPARATOR = new Uint8Array([0xe3, 0x80, 0x80]);
+
+function equalBytes(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return false;
+  }
+  return true;
+}
+
+function splitMnemonicBytes(mnemonic: Uint8Array): Uint8Array[] {
+  const separator = isJapaneseWordSeparator(mnemonic)
+    ? JAPANESE_MNEMONIC_SEPARATOR
+    : new Uint8Array([WORD_SEPARATOR]);
+  const words: Uint8Array[] = [];
+  let start = 0;
+
+  for (let i = 0; i <= mnemonic.length - separator.length; ) {
+    if (equalBytes(mnemonic.subarray(i, i + separator.length), separator)) {
+      words.push(mnemonic.subarray(start, i));
+      i += separator.length;
+      start = i;
+      continue;
+    }
+    i += 1;
+  }
+
+  words.push(mnemonic.subarray(start));
+  if (![12, 15, 18, 21, 24].includes(words.length)) throw new Error('Invalid mnemonic');
+  return words;
+}
+
+function isJapaneseWordSeparator(bytes: Uint8Array): boolean {
+  for (let i = 0; i <= bytes.length - JAPANESE_MNEMONIC_SEPARATOR.length; i++) {
+    if (
+      equalBytes(
+        bytes.subarray(i, i + JAPANESE_MNEMONIC_SEPARATOR.length),
+        JAPANESE_MNEMONIC_SEPARATOR
+      )
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function decodeMnemonicWordIndexes(words: Uint8Array[], wordlist: string[]): number[] {
+  const encodedWordlist = wordlist.map((word) => nfkdBytes(word));
+
+  return words.map((word) => {
+    for (let i = 0; i < encodedWordlist.length; i++) {
+      if (equalBytes(word, encodedWordlist[i])) return i;
+    }
+    throw new Error('Invalid mnemonic');
+  });
+}
+
+function decodeMnemonicEntropy(wordIndexes: number[]): Uint8Array {
+  const entropy = new Uint8Array((wordIndexes.length / 3) * 4);
+  const entropyBitLength = entropy.length * 8;
+  const checksumBitLength = entropy.length / 4;
+  let checksum = 0;
+  let bitIndex = 0;
+
+  for (const wordIndex of wordIndexes) {
+    for (let bit = 10; bit >= 0; bit--) {
+      const value = (wordIndex >> bit) & 1;
+
+      if (bitIndex < entropyBitLength) {
+        if (value) entropy[bitIndex >> 3] |= 1 << (7 - (bitIndex & 7));
+      } else {
+        checksum = (checksum << 1) | value;
+      }
+
+      bitIndex += 1;
+    }
+  }
+
+  aentropy(entropy);
+  const expectedChecksum = sha256(entropy)[0]! >> (8 - checksumBitLength);
+  if (checksum !== expectedChecksum) throw new Error('Invalid mnemonic');
+  return entropy;
+}
+
+function nfkdBytes(value: string | Uint8Array): Uint8Array {
+  if (value instanceof Uint8Array && isASCII(value)) return value;
+  const normalized =
+    typeof value === 'string'
+      ? value.normalize('NFKD')
+      : new TextDecoder().decode(value).normalize('NFKD');
+  return new TextEncoder().encode(normalized);
+}
+
+/**
+ * Generates a mnemonic as UTF-8 bytes.
+ * @param wordlist - Imported wordlist for a specific language.
+ * @param strength - Entropy strength in bits. Default is 128.
+ * @returns 12-24 words encoded as UTF-8 bytes.
+ * @throws On wrong argument types. {@link TypeError}
+ * @throws On wrong argument ranges or values. {@link RangeError}
+ * @example
+ * Generate a mutable English mnemonic buffer.
+ * ```ts
+ * import { generateMnemonicBytes } from '@scure/bip39';
+ * import { wordlist } from '@scure/bip39/wordlists/english.js';
+ * const mnemonic = generateMnemonicBytes(wordlist, 128);
+ * const text = new TextDecoder().decode(mnemonic);
+ * // 'legal winner thank year wave sausage worth useful legal winner thank yellow'
+ * ```
+ */
+export function generateMnemonicBytes(wordlist: string[], strength: number = 128): Uint8Array {
+  anumber(strength);
+  if (strength % 32 !== 0 || strength > 256) throw new RangeError('Invalid entropy');
+  return entropyToMnemonicBytes(randomBytes(strength / 8), wordlist);
+}
+
+/**
+ * Reversible: Converts raw entropy in form of byte array to mnemonic UTF-8 bytes.
+ * @param entropy - Byte array.
+ * @param wordlist - Imported wordlist for a specific language.
+ * @returns 12-24 words encoded as UTF-8 bytes.
+ * @throws On wrong argument types. {@link TypeError}
+ * @throws On wrong argument ranges or values. {@link RangeError}
+ * @example
+ * Convert raw entropy into mnemonic bytes.
+ * ```ts
+ * import { entropyToMnemonicBytes } from '@scure/bip39';
+ * import { wordlist } from '@scure/bip39/wordlists/english.js';
+ * const ent = new Uint8Array([
+ *   0x7f, 0x7f, 0x7f, 0x7f, 0x7f, 0x7f, 0x7f, 0x7f,
+ *   0x7f, 0x7f, 0x7f, 0x7f, 0x7f, 0x7f, 0x7f, 0x7f
+ * ]);
+ * const mnemonic = entropyToMnemonicBytes(ent, wordlist);
+ * const text = new TextDecoder().decode(mnemonic);
+ * // 'legal winner thank year wave sausage worth useful legal winner thank yellow'
+ * ```
+ */
+export function entropyToMnemonicBytes(entropy: TArg<Uint8Array>, wordlist: string[]): Uint8Array {
+  aentropy(entropy);
+  const words = getCoder(wordlist).encode(entropy);
+  const sep = isJapanese(wordlist) ? JAPANESE_MNEMONIC_SEPARATOR : new Uint8Array([WORD_SEPARATOR]);
+  const encoder = new TextEncoder();
+  const wordBytes = words.map((w) => encoder.encode(w));
+  let totalLen = 0;
+  for (let i = 0; i < wordBytes.length; i++) {
+    totalLen += wordBytes[i].length;
+    if (i < wordBytes.length - 1) totalLen += sep.length;
+  }
+  const res = new Uint8Array(totalLen);
+  let pos = 0;
+  for (let i = 0; i < wordBytes.length; i++) {
+    res.set(wordBytes[i], pos);
+    pos += wordBytes[i].length;
+    if (i < wordBytes.length - 1) {
+      res.set(sep, pos);
+      pos += sep.length;
+    }
+  }
+  return res;
+}
+
+/**
+ * Reversible: Converts mnemonic UTF-8 bytes to raw entropy bytes.
+ * @param mnemonic - UTF-8 bytes containing 12-24 words.
+ * @param wordlist - Imported wordlist for a specific language.
+ * @returns Raw entropy bytes.
+ * @throws If the mnemonic shape or checksum is invalid. {@link Error}
+ * @throws On wrong argument types. {@link TypeError}
+ * @throws On wrong argument ranges or values. {@link RangeError}
+ * @example
+ * Decode mnemonic bytes back into entropy.
+ * ```ts
+ * import { mnemonicToEntropyFromBytes } from '@scure/bip39';
+ * import { wordlist } from '@scure/bip39/wordlists/english.js';
+ * const mnemonic = new TextEncoder().encode(
+ *   'legal winner thank year wave sausage worth useful legal winner thank yellow'
+ * );
+ * const entropy = mnemonicToEntropyFromBytes(mnemonic, wordlist);
+ * // Produces the original 16-byte entropy payload.
+ * ```
+ */
+export function mnemonicToEntropyFromBytes(mnemonic: Uint8Array, wordlist: string[]): Uint8Array {
+  getCoder(wordlist);
+  const normalizedMnemonic = nfkdBytes(mnemonic);
+  const words = splitMnemonicBytes(normalizedMnemonic);
+  const wordIndexes = decodeMnemonicWordIndexes(words, wordlist);
+  return decodeMnemonicEntropy(wordIndexes);
+}
+
+/**
+ * Validates mnemonic bytes for being 12-24 words contained in `wordlist`.
+ * @param mnemonic - UTF-8 bytes containing 12-24 words.
+ * @param wordlist - Imported wordlist for a specific language.
+ * @returns `true` when mnemonic checksum and words are valid.
+ * @example
+ * Validate one English mnemonic encoded as bytes.
+ * ```ts
+ * import { validateMnemonicFromBytes } from '@scure/bip39';
+ * import { wordlist } from '@scure/bip39/wordlists/english.js';
+ * const ok = validateMnemonicFromBytes(
+ *   new TextEncoder().encode(
+ *     'legal winner thank year wave sausage worth useful legal winner thank yellow'
+ *   ),
+ *   wordlist
+ * );
+ * // => true
+ * ```
+ */
+export function bip39ValidateMnemonicFromBytes(
+  mnemonic: Uint8Array,
+  wordlist: string[]
+): boolean {
+  try {
+    mnemonicToEntropyFromBytes(mnemonic, wordlist);
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
+
+/** Alias for {@link bip39ValidateMnemonicFromBytes}. */
+export const validateMnemonicFromBytes: (
+  mnemonic: Uint8Array,
+  wordlist: string[]
+) => boolean = bip39ValidateMnemonicFromBytes;
+
+/**
+ * Irreversible: Uses KDF to derive 64 bytes of key data from mnemonic bytes + optional password bytes.
+ * @param mnemonic - UTF-8 bytes containing 12-24 words.
+ * @param passphrase - UTF-8 bytes that will additionally protect the key.
+ * @returns 64 bytes of key data.
+ * @throws If the mnemonic shape is invalid. {@link Error}
+ * @throws On wrong argument types. {@link TypeError}
+ * @example
+ * Derive a seed from byte inputs with the sync PBKDF2 helper.
+ * ```ts
+ * import { mnemonicToSeedSyncFromBytes } from '@scure/bip39';
+ * const mnemonic = new TextEncoder().encode(
+ *   'legal winner thank year wave sausage worth useful legal winner thank yellow'
+ * );
+ * const passphrase = new TextEncoder().encode('password');
+ * const seed = mnemonicToSeedSyncFromBytes(mnemonic, passphrase);
+ * // => new Uint8Array([...64 bytes])
+ * ```
+ */
+export function mnemonicToSeedSyncFromBytes(
+  mnemonic: Uint8Array,
+  passphrase: Uint8Array = new Uint8Array()
+): Uint8Array {
+  const m = nfkdBytes(mnemonic);
+  const p = nfkdBytes(passphrase);
+  const salt = new Uint8Array(MNEMONIC_SALT_PREFIX.length + p.length);
+  salt.set(MNEMONIC_SALT_PREFIX);
+  salt.set(p, MNEMONIC_SALT_PREFIX.length);
+  return pbkdf2(sha512, m, salt, { c: 2048, dkLen: 64 }) as Uint8Array;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -507,6 +507,31 @@ export function mnemonicToSeedSyncFromBytes(
 }
 
 /**
+ * Irreversible: Uses native WebCrypto KDF to derive 64 bytes of key data from mnemonic bytes + optional password bytes.
+ * 
+ * @param mnemonic - UTF-8 bytes containing 12-24 words.
+ * @param passphrase - UTF-8 bytes that will additionally protect the key.
+ * @returns 64 bytes of key data.
+ */
+export async function mnemonicToSeedFromBytesWebcrypto(
+  mnemonic: Uint8Array,
+  passphrase: Uint8Array = new Uint8Array()
+): Promise<Uint8Array> {
+  const m = nfkdBytes(mnemonic);
+  const p = nfkdBytes(passphrase);
+  const salt = new Uint8Array(MNEMONIC_SALT_PREFIX.length + p.length);
+  try {
+    salt.set(MNEMONIC_SALT_PREFIX);
+    salt.set(p, MNEMONIC_SALT_PREFIX.length);
+    return (await pbkdf2web(sha512web, m, salt, { c: 2048, dkLen: 64 })) as Uint8Array;
+  } finally {
+    salt.fill(0);
+    if (m !== mnemonic) m.fill(0);
+    if (p !== passphrase) p.fill(0);
+  }
+}
+
+/**
  * Irreversible: Uses KDF to derive 64 bytes of key data from mnemonic bytes + optional password bytes.
  *
  * Note: This is the primitive BIP-39 operation. It does not require a wordlist and

--- a/src/index.ts
+++ b/src/index.ts
@@ -480,6 +480,10 @@ export function validateMnemonicFromBytes(
 
 /**
  * Irreversible: Uses KDF to derive 64 bytes of key data from mnemonic bytes + optional password bytes.
+ *
+ * Note: This is the primitive BIP-39 operation. It does not require a wordlist and
+ * will work even if the mnemonic checksum is invalid, as per BIP-39 specification.
+ *
  * @param mnemonic - UTF-8 bytes containing 12-24 words.
  * @param passphrase - UTF-8 bytes that will additionally protect the key.
  * @returns 64 bytes of key data.
@@ -504,6 +508,10 @@ export function mnemonicToSeedSyncFromBytes(
 
 /**
  * Irreversible: Uses KDF to derive 64 bytes of key data from mnemonic bytes + optional password bytes.
+ *
+ * Note: This is the primitive BIP-39 operation. It does not require a wordlist and
+ * will work even if the mnemonic checksum is invalid, as per BIP-39 specification.
+ *
  * @param mnemonic - UTF-8 bytes containing 12-24 words.
  * @param passphrase - UTF-8 bytes that will additionally protect the key.
  * @returns 64 bytes of key data.

--- a/src/index.ts
+++ b/src/index.ts
@@ -260,7 +260,7 @@ const WORD_SEPARATOR = 0x20;
 const MNEMONIC_SALT_PREFIX = new Uint8Array([109, 110, 101, 109, 111, 110, 105, 99]); // "mnemonic"
 const JAPANESE_MNEMONIC_SEPARATOR = new Uint8Array([0xe3, 0x80, 0x80]);
 
-function equalBytes(a: Uint8Array, b: Uint8Array): boolean {
+export function equalBytes(a: Uint8Array, b: Uint8Array): boolean {
   if (a.length !== b.length) return false;
   for (let i = 0; i < a.length; i++) {
     if (a[i] !== b[i]) return false;
@@ -268,7 +268,7 @@ function equalBytes(a: Uint8Array, b: Uint8Array): boolean {
   return true;
 }
 
-function splitMnemonicBytes(mnemonic: Uint8Array): Uint8Array[] {
+export function splitMnemonicBytes(mnemonic: Uint8Array): Uint8Array[] {
   const separator = isJapaneseWordSeparator(mnemonic)
     ? JAPANESE_MNEMONIC_SEPARATOR
     : new Uint8Array([WORD_SEPARATOR]);
@@ -354,13 +354,40 @@ function decodeMnemonicEntropy(wordIndexes: number[]): Uint8Array {
   return entropy;
 }
 
-function nfkdBytes(value: string | Uint8Array): Uint8Array {
+export function nfkdBytes(value: string | Uint8Array): Uint8Array {
   if (value instanceof Uint8Array && isASCII(value)) return value;
   const normalized =
     typeof value === 'string'
       ? value.normalize('NFKD')
       : new TextDecoder().decode(value).normalize('NFKD');
   return new TextEncoder().encode(normalized);
+}
+
+/**
+ * Normalizes mnemonic bytes: trims, replaces multiple spaces/newlines with single space, 
+ * and converts to lowercase. NFKD normalization is applied via split/decode/encode.
+ */
+export function normalizeMnemonicBytes(mnemonic: Uint8Array): Uint8Array {
+  const isWhitespace = (b: number) => b === 0x20 || b === 0x09 || b === 0x0a || b === 0x0d;
+  const temp = new Uint8Array(mnemonic.length);
+  let out = 0;
+  let lastWasSpace = true;
+  for (let i = 0; i < mnemonic.length; i++) {
+    const byte = mnemonic[i];
+    if (isWhitespace(byte)) {
+      if (!lastWasSpace) {
+        temp[out++] = 0x20;
+        lastWasSpace = true;
+      }
+      continue;
+    }
+    temp[out++] = byte >= 0x41 && byte <= 0x5a ? byte + 0x20 : byte;
+    lastWasSpace = false;
+  }
+  if (out > 0 && temp[out - 1] === 0x20) out -= 1;
+  const res = temp.slice(0, out);
+  temp.fill(0);
+  return res;
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -260,6 +260,88 @@ const WORD_SEPARATOR = 0x20;
 const MNEMONIC_SALT_PREFIX = new Uint8Array([109, 110, 101, 109, 111, 110, 105, 99]); // "mnemonic"
 const JAPANESE_MNEMONIC_SEPARATOR = new Uint8Array([0xe3, 0x80, 0x80]);
 
+function equalBytes(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return false;
+  }
+  return true;
+}
+
+function splitMnemonicBytes(mnemonic: Uint8Array): Uint8Array[] {
+  const separator = isJapaneseWordSeparator(mnemonic)
+    ? JAPANESE_MNEMONIC_SEPARATOR
+    : new Uint8Array([WORD_SEPARATOR]);
+  const words: Uint8Array[] = [];
+  let start = 0;
+
+  for (let i = 0; i <= mnemonic.length - separator.length; ) {
+    if (equalBytes(mnemonic.subarray(i, i + separator.length), separator)) {
+      words.push(mnemonic.subarray(start, i));
+      i += separator.length;
+      start = i;
+      continue;
+    }
+    i += 1;
+  }
+
+  words.push(mnemonic.subarray(start));
+  if (![12, 15, 18, 21, 24].includes(words.length)) throw new Error('Invalid mnemonic');
+  return words;
+}
+
+function isJapaneseWordSeparator(bytes: Uint8Array): boolean {
+  for (let i = 0; i <= bytes.length - JAPANESE_MNEMONIC_SEPARATOR.length; i++) {
+    if (
+      equalBytes(
+        bytes.subarray(i, i + JAPANESE_MNEMONIC_SEPARATOR.length),
+        JAPANESE_MNEMONIC_SEPARATOR
+      )
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function decodeMnemonicWordIndexes(words: Uint8Array[], wordlist: string[]): number[] {
+  const encodedWordlist = wordlist.map((word) => nfkdBytes(word));
+
+  return words.map((word) => {
+    for (let i = 0; i < encodedWordlist.length; i++) {
+      if (equalBytes(word, encodedWordlist[i])) return i;
+    }
+    throw new Error('Invalid mnemonic');
+  });
+}
+
+function decodeMnemonicEntropy(wordIndexes: number[]): Uint8Array {
+  const entropy = new Uint8Array((wordIndexes.length / 3) * 4);
+  const entropyBitLength = entropy.length * 8;
+  const checksumBitLength = entropy.length / 4;
+  let checksum = 0;
+  let bitIndex = 0;
+
+  for (const wordIndex of wordIndexes) {
+    for (let bit = 10; bit >= 0; bit--) {
+      const value = (wordIndex >> bit) & 1;
+
+      if (bitIndex < entropyBitLength) {
+        if (value) entropy[bitIndex >> 3] |= 1 << (7 - (bitIndex & 7));
+      } else {
+        checksum = (checksum << 1) | value;
+      }
+
+      bitIndex += 1;
+    }
+  }
+
+  aentropy(entropy);
+  const expectedChecksum = sha256(entropy)[0]! >> (8 - checksumBitLength);
+  if (checksum !== expectedChecksum) throw new Error('Invalid mnemonic');
+  return entropy;
+}
+
 function nfkdBytes(value: string | Uint8Array): Uint8Array {
   if (value instanceof Uint8Array && isASCII(value)) return value;
   const normalized =
@@ -334,6 +416,52 @@ export function entropyToMnemonicBytes(entropy: TArg<Uint8Array>, wordlist: stri
     }
   }
   return res;
+}
+
+/**
+ * Reversible: Converts mnemonic UTF-8 bytes to raw entropy bytes.
+ * @param mnemonic - UTF-8 bytes containing 12-24 words.
+ * @param wordlist - Imported wordlist for a specific language.
+ * @returns Raw entropy bytes.
+ * @throws If the mnemonic shape or checksum is invalid. {@link Error}
+ * @throws On wrong argument types. {@link TypeError}
+ * @throws On wrong argument ranges or values. {@link RangeError}
+ * @example
+ * Decode mnemonic bytes back into entropy.
+ * ```ts
+ * import { mnemonicToEntropyFromBytes } from '@scure/bip39';
+ * import { wordlist } from '@scure/bip39/wordlists/english.js';
+ * const mnemonic = new TextEncoder().encode(
+ *   'legal winner thank year wave sausage worth useful legal winner thank yellow'
+ * );
+ * const entropy = mnemonicToEntropyFromBytes(mnemonic, wordlist);
+ * // Produces the original 16-byte entropy payload.
+ * ```
+ */
+export function mnemonicToEntropyFromBytes(mnemonic: Uint8Array, wordlist: string[]): Uint8Array {
+  getCoder(wordlist);
+  const normalizedMnemonic = nfkdBytes(mnemonic);
+  const words = splitMnemonicBytes(normalizedMnemonic);
+  const wordIndexes = decodeMnemonicWordIndexes(words, wordlist);
+  return decodeMnemonicEntropy(wordIndexes);
+}
+
+/**
+ * Validates mnemonic bytes for being 12-24 words contained in `wordlist`.
+ * @param mnemonic - UTF-8 bytes containing 12-24 words.
+ * @param wordlist - Imported wordlist for a specific language.
+ * @returns `true` when mnemonic checksum and words are valid.
+ */
+export function bip39ValidateMnemonicFromBytes(
+  mnemonic: Uint8Array,
+  wordlist: string[]
+): boolean {
+  try {
+    mnemonicToEntropyFromBytes(mnemonic, wordlist);
+    return true;
+  } catch (e) {
+    return false;
+  }
 }
 
 function mnemonicToSeedSyncFromBytes(

--- a/src/index.ts
+++ b/src/index.ts
@@ -304,8 +304,20 @@ function isJapaneseWordSeparator(bytes: Uint8Array): boolean {
   return false;
 }
 
+const ENCODED_WORDLIST_CACHE = new WeakMap<string[], Uint8Array[]>();
+
+// caches encoded wordlist to avoid re-allocating 2048 arrays on every validation
+function getEncodedWordlist(wordlist: string[]): Uint8Array[] {
+  let cached = ENCODED_WORDLIST_CACHE.get(wordlist);
+  if (!cached) {
+    cached = wordlist.map((word) => nfkdBytes(word));
+    ENCODED_WORDLIST_CACHE.set(wordlist, cached);
+  }
+  return cached;
+}
+
 function decodeMnemonicWordIndexes(words: Uint8Array[], wordlist: string[]): number[] {
-  const encodedWordlist = wordlist.map((word) => nfkdBytes(word));
+  const encodedWordlist = getEncodedWordlist(wordlist);
 
   return words.map((word) => {
     for (let i = 0; i < encodedWordlist.length; i++) {
@@ -410,6 +422,7 @@ export function entropyToMnemonicBytes(entropy: TArg<Uint8Array>, wordlist: stri
   for (let i = 0; i < wordBytes.length; i++) {
     res.set(wordBytes[i], pos);
     pos += wordBytes[i].length;
+    wordBytes[i].fill(0); // Clear individual word buffer
     if (i < wordBytes.length - 1) {
       res.set(sep, pos);
       pos += sep.length;
@@ -457,7 +470,8 @@ export function validateMnemonicFromBytes(
   wordlist: string[]
 ): boolean {
   try {
-    mnemonicToEntropyFromBytes(mnemonic, wordlist);
+    const entropy = mnemonicToEntropyFromBytes(mnemonic, wordlist);
+    entropy.fill(0);
     return true;
   } catch (e) {
     return false;
@@ -477,9 +491,15 @@ export function mnemonicToSeedSyncFromBytes(
   const m = nfkdBytes(mnemonic);
   const p = nfkdBytes(passphrase);
   const salt = new Uint8Array(MNEMONIC_SALT_PREFIX.length + p.length);
-  salt.set(MNEMONIC_SALT_PREFIX);
-  salt.set(p, MNEMONIC_SALT_PREFIX.length);
-  return pbkdf2(sha512, m, salt, { c: 2048, dkLen: 64 }) as Uint8Array;
+  try {
+    salt.set(MNEMONIC_SALT_PREFIX);
+    salt.set(p, MNEMONIC_SALT_PREFIX.length);
+    return pbkdf2(sha512, m, salt, { c: 2048, dkLen: 64 }) as Uint8Array;
+  } finally {
+    salt.fill(0);
+    if (m !== mnemonic) m.fill(0);
+    if (p !== passphrase) p.fill(0);
+  }
 }
 
 /**
@@ -488,16 +508,22 @@ export function mnemonicToSeedSyncFromBytes(
  * @param passphrase - UTF-8 bytes that will additionally protect the key.
  * @returns 64 bytes of key data.
  */
-export function mnemonicToSeedFromBytes(
+export async function mnemonicToSeedFromBytes(
   mnemonic: Uint8Array,
   passphrase: Uint8Array = new Uint8Array()
 ): Promise<Uint8Array> {
   const m = nfkdBytes(mnemonic);
   const p = nfkdBytes(passphrase);
   const salt = new Uint8Array(MNEMONIC_SALT_PREFIX.length + p.length);
-  salt.set(MNEMONIC_SALT_PREFIX);
-  salt.set(p, MNEMONIC_SALT_PREFIX.length);
-  return pbkdf2Async(sha512, m, salt, { c: 2048, dkLen: 64 }) as Promise<Uint8Array>;
+  try {
+    salt.set(MNEMONIC_SALT_PREFIX);
+    salt.set(p, MNEMONIC_SALT_PREFIX.length);
+    return (await pbkdf2Async(sha512, m, salt, { c: 2048, dkLen: 64 })) as Uint8Array;
+  } finally {
+    salt.fill(0);
+    if (m !== mnemonic) m.fill(0);
+    if (p !== passphrase) p.fill(0);
+  }
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -260,88 +260,6 @@ const WORD_SEPARATOR = 0x20;
 const MNEMONIC_SALT_PREFIX = new Uint8Array([109, 110, 101, 109, 111, 110, 105, 99]); // "mnemonic"
 const JAPANESE_MNEMONIC_SEPARATOR = new Uint8Array([0xe3, 0x80, 0x80]);
 
-function equalBytes(a: Uint8Array, b: Uint8Array): boolean {
-  if (a.length !== b.length) return false;
-  for (let i = 0; i < a.length; i++) {
-    if (a[i] !== b[i]) return false;
-  }
-  return true;
-}
-
-function splitMnemonicBytes(mnemonic: Uint8Array): Uint8Array[] {
-  const separator = isJapaneseWordSeparator(mnemonic)
-    ? JAPANESE_MNEMONIC_SEPARATOR
-    : new Uint8Array([WORD_SEPARATOR]);
-  const words: Uint8Array[] = [];
-  let start = 0;
-
-  for (let i = 0; i <= mnemonic.length - separator.length; ) {
-    if (equalBytes(mnemonic.subarray(i, i + separator.length), separator)) {
-      words.push(mnemonic.subarray(start, i));
-      i += separator.length;
-      start = i;
-      continue;
-    }
-    i += 1;
-  }
-
-  words.push(mnemonic.subarray(start));
-  if (![12, 15, 18, 21, 24].includes(words.length)) throw new Error('Invalid mnemonic');
-  return words;
-}
-
-function isJapaneseWordSeparator(bytes: Uint8Array): boolean {
-  for (let i = 0; i <= bytes.length - JAPANESE_MNEMONIC_SEPARATOR.length; i++) {
-    if (
-      equalBytes(
-        bytes.subarray(i, i + JAPANESE_MNEMONIC_SEPARATOR.length),
-        JAPANESE_MNEMONIC_SEPARATOR
-      )
-    ) {
-      return true;
-    }
-  }
-  return false;
-}
-
-function decodeMnemonicWordIndexes(words: Uint8Array[], wordlist: string[]): number[] {
-  const encodedWordlist = wordlist.map((word) => nfkdBytes(word));
-
-  return words.map((word) => {
-    for (let i = 0; i < encodedWordlist.length; i++) {
-      if (equalBytes(word, encodedWordlist[i])) return i;
-    }
-    throw new Error('Invalid mnemonic');
-  });
-}
-
-function decodeMnemonicEntropy(wordIndexes: number[]): Uint8Array {
-  const entropy = new Uint8Array((wordIndexes.length / 3) * 4);
-  const entropyBitLength = entropy.length * 8;
-  const checksumBitLength = entropy.length / 4;
-  let checksum = 0;
-  let bitIndex = 0;
-
-  for (const wordIndex of wordIndexes) {
-    for (let bit = 10; bit >= 0; bit--) {
-      const value = (wordIndex >> bit) & 1;
-
-      if (bitIndex < entropyBitLength) {
-        if (value) entropy[bitIndex >> 3] |= 1 << (7 - (bitIndex & 7));
-      } else {
-        checksum = (checksum << 1) | value;
-      }
-
-      bitIndex += 1;
-    }
-  }
-
-  aentropy(entropy);
-  const expectedChecksum = sha256(entropy)[0]! >> (8 - checksumBitLength);
-  if (checksum !== expectedChecksum) throw new Error('Invalid mnemonic');
-  return entropy;
-}
-
 function nfkdBytes(value: string | Uint8Array): Uint8Array {
   if (value instanceof Uint8Array && isASCII(value)) return value;
   const normalized =
@@ -352,26 +270,25 @@ function nfkdBytes(value: string | Uint8Array): Uint8Array {
 }
 
 /**
- * Generates a mnemonic as UTF-8 bytes.
- * @param wordlist - Imported wordlist for a specific language.
+ * Generates random entropy bytes suitable for BIP-39 mnemonics.
  * @param strength - Entropy strength in bits. Default is 128.
- * @returns 12-24 words encoded as UTF-8 bytes.
+ * @returns Raw entropy bytes.
  * @throws On wrong argument types. {@link TypeError}
  * @throws On wrong argument ranges or values. {@link RangeError}
  * @example
- * Generate a mutable English mnemonic buffer.
+ * Generate a mutable entropy buffer.
  * ```ts
- * import { generateMnemonicBytes } from '@scure/bip39';
+ * import { entropyToMnemonicBytes, generateEntropyBytes } from '@scure/bip39';
  * import { wordlist } from '@scure/bip39/wordlists/english.js';
- * const mnemonic = generateMnemonicBytes(wordlist, 128);
- * const text = new TextDecoder().decode(mnemonic);
- * // 'legal winner thank year wave sausage worth useful legal winner thank yellow'
+ * const entropy = generateEntropyBytes(128);
+ * const mnemonic = entropyToMnemonicBytes(entropy, wordlist);
  * ```
  */
-export function generateMnemonicBytes(wordlist: string[], strength: number = 128): Uint8Array {
+export function generateEntropyBytes(strength: number = 128): Uint8Array {
   anumber(strength);
-  if (strength % 32 !== 0 || strength > 256) throw new RangeError('Invalid entropy');
-  return entropyToMnemonicBytes(randomBytes(strength / 8), wordlist);
+  if (strength % 32 !== 0 || strength < 128 || strength > 256)
+    throw new RangeError('Invalid entropy');
+  return randomBytes(strength / 8);
 }
 
 /**
@@ -419,91 +336,7 @@ export function entropyToMnemonicBytes(entropy: TArg<Uint8Array>, wordlist: stri
   return res;
 }
 
-/**
- * Reversible: Converts mnemonic UTF-8 bytes to raw entropy bytes.
- * @param mnemonic - UTF-8 bytes containing 12-24 words.
- * @param wordlist - Imported wordlist for a specific language.
- * @returns Raw entropy bytes.
- * @throws If the mnemonic shape or checksum is invalid. {@link Error}
- * @throws On wrong argument types. {@link TypeError}
- * @throws On wrong argument ranges or values. {@link RangeError}
- * @example
- * Decode mnemonic bytes back into entropy.
- * ```ts
- * import { mnemonicToEntropyFromBytes } from '@scure/bip39';
- * import { wordlist } from '@scure/bip39/wordlists/english.js';
- * const mnemonic = new TextEncoder().encode(
- *   'legal winner thank year wave sausage worth useful legal winner thank yellow'
- * );
- * const entropy = mnemonicToEntropyFromBytes(mnemonic, wordlist);
- * // Produces the original 16-byte entropy payload.
- * ```
- */
-export function mnemonicToEntropyFromBytes(mnemonic: Uint8Array, wordlist: string[]): Uint8Array {
-  getCoder(wordlist);
-  const normalizedMnemonic = nfkdBytes(mnemonic);
-  const words = splitMnemonicBytes(normalizedMnemonic);
-  const wordIndexes = decodeMnemonicWordIndexes(words, wordlist);
-  return decodeMnemonicEntropy(wordIndexes);
-}
-
-/**
- * Validates mnemonic bytes for being 12-24 words contained in `wordlist`.
- * @param mnemonic - UTF-8 bytes containing 12-24 words.
- * @param wordlist - Imported wordlist for a specific language.
- * @returns `true` when mnemonic checksum and words are valid.
- * @example
- * Validate one English mnemonic encoded as bytes.
- * ```ts
- * import { validateMnemonicFromBytes } from '@scure/bip39';
- * import { wordlist } from '@scure/bip39/wordlists/english.js';
- * const ok = validateMnemonicFromBytes(
- *   new TextEncoder().encode(
- *     'legal winner thank year wave sausage worth useful legal winner thank yellow'
- *   ),
- *   wordlist
- * );
- * // => true
- * ```
- */
-export function bip39ValidateMnemonicFromBytes(
-  mnemonic: Uint8Array,
-  wordlist: string[]
-): boolean {
-  try {
-    mnemonicToEntropyFromBytes(mnemonic, wordlist);
-    return true;
-  } catch (e) {
-    return false;
-  }
-}
-
-/** Alias for {@link bip39ValidateMnemonicFromBytes}. */
-export const validateMnemonicFromBytes: (
-  mnemonic: Uint8Array,
-  wordlist: string[]
-) => boolean = bip39ValidateMnemonicFromBytes;
-
-/**
- * Irreversible: Uses KDF to derive 64 bytes of key data from mnemonic bytes + optional password bytes.
- * @param mnemonic - UTF-8 bytes containing 12-24 words.
- * @param passphrase - UTF-8 bytes that will additionally protect the key.
- * @returns 64 bytes of key data.
- * @throws If the mnemonic shape is invalid. {@link Error}
- * @throws On wrong argument types. {@link TypeError}
- * @example
- * Derive a seed from byte inputs with the sync PBKDF2 helper.
- * ```ts
- * import { mnemonicToSeedSyncFromBytes } from '@scure/bip39';
- * const mnemonic = new TextEncoder().encode(
- *   'legal winner thank year wave sausage worth useful legal winner thank yellow'
- * );
- * const passphrase = new TextEncoder().encode('password');
- * const seed = mnemonicToSeedSyncFromBytes(mnemonic, passphrase);
- * // => new Uint8Array([...64 bytes])
- * ```
- */
-export function mnemonicToSeedSyncFromBytes(
+function mnemonicToSeedSyncFromBytes(
   mnemonic: Uint8Array,
   passphrase: Uint8Array = new Uint8Array()
 ): Uint8Array {
@@ -513,4 +346,39 @@ export function mnemonicToSeedSyncFromBytes(
   salt.set(MNEMONIC_SALT_PREFIX);
   salt.set(p, MNEMONIC_SALT_PREFIX.length);
   return pbkdf2(sha512, m, salt, { c: 2048, dkLen: 64 }) as Uint8Array;
+}
+
+/**
+ * Irreversible: Derives a BIP-39 seed directly from entropy bytes.
+ *
+ * Note that BIP-39 seeds are derived from the mnemonic sentence, so the
+ * selected wordlist and passphrase are part of the result.
+ *
+ * @param entropy - Raw BIP-39 entropy bytes.
+ * @param wordlist - Imported wordlist for a specific language.
+ * @param passphrase - UTF-8 bytes that will additionally protect the seed.
+ * @returns 64 bytes of key data.
+ * @throws On wrong argument types. {@link TypeError}
+ * @throws On wrong argument ranges or values. {@link RangeError}
+ * @example
+ * Derive a seed from entropy without exposing a mnemonic string to the caller.
+ * ```ts
+ * import { entropyToSeedSyncFromBytes } from '@scure/bip39';
+ * import { wordlist } from '@scure/bip39/wordlists/english.js';
+ * const entropy = new Uint8Array(16);
+ * const seed = entropyToSeedSyncFromBytes(entropy, wordlist);
+ * // => new Uint8Array([...64 bytes])
+ * ```
+ */
+export function entropyToSeedSyncFromBytes(
+  entropy: TArg<Uint8Array>,
+  wordlist: string[],
+  passphrase: Uint8Array = new Uint8Array()
+): Uint8Array {
+  const mnemonic = entropyToMnemonicBytes(entropy, wordlist);
+  try {
+    return mnemonicToSeedSyncFromBytes(mnemonic, passphrase);
+  } finally {
+    mnemonic.fill(0);
+  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -452,7 +452,7 @@ export function mnemonicToEntropyFromBytes(mnemonic: Uint8Array, wordlist: strin
  * @param wordlist - Imported wordlist for a specific language.
  * @returns `true` when mnemonic checksum and words are valid.
  */
-export function bip39ValidateMnemonicFromBytes(
+export function validateMnemonicFromBytes(
   mnemonic: Uint8Array,
   wordlist: string[]
 ): boolean {
@@ -464,7 +464,13 @@ export function bip39ValidateMnemonicFromBytes(
   }
 }
 
-function mnemonicToSeedSyncFromBytes(
+/**
+ * Irreversible: Uses KDF to derive 64 bytes of key data from mnemonic bytes + optional password bytes.
+ * @param mnemonic - UTF-8 bytes containing 12-24 words.
+ * @param passphrase - UTF-8 bytes that will additionally protect the key.
+ * @returns 64 bytes of key data.
+ */
+export function mnemonicToSeedSyncFromBytes(
   mnemonic: Uint8Array,
   passphrase: Uint8Array = new Uint8Array()
 ): Uint8Array {
@@ -474,6 +480,24 @@ function mnemonicToSeedSyncFromBytes(
   salt.set(MNEMONIC_SALT_PREFIX);
   salt.set(p, MNEMONIC_SALT_PREFIX.length);
   return pbkdf2(sha512, m, salt, { c: 2048, dkLen: 64 }) as Uint8Array;
+}
+
+/**
+ * Irreversible: Uses KDF to derive 64 bytes of key data from mnemonic bytes + optional password bytes.
+ * @param mnemonic - UTF-8 bytes containing 12-24 words.
+ * @param passphrase - UTF-8 bytes that will additionally protect the key.
+ * @returns 64 bytes of key data.
+ */
+export function mnemonicToSeedFromBytes(
+  mnemonic: Uint8Array,
+  passphrase: Uint8Array = new Uint8Array()
+): Promise<Uint8Array> {
+  const m = nfkdBytes(mnemonic);
+  const p = nfkdBytes(passphrase);
+  const salt = new Uint8Array(MNEMONIC_SALT_PREFIX.length + p.length);
+  salt.set(MNEMONIC_SALT_PREFIX);
+  salt.set(p, MNEMONIC_SALT_PREFIX.length);
+  return pbkdf2Async(sha512, m, salt, { c: 2048, dkLen: 64 }) as Promise<Uint8Array>;
 }
 
 /**

--- a/test/bip39.test.ts
+++ b/test/bip39.test.ts
@@ -2,18 +2,49 @@ import { bytesToHex, hexToBytes } from '@noble/hashes/utils.js';
 import { describe, should } from '@paulmillr/jsbt/test.js';
 import {
   entropyToMnemonic,
+  entropyToMnemonicBytes,
   generateMnemonic,
+  generateMnemonicBytes,
   mnemonicToEntropy,
+  mnemonicToEntropyFromBytes,
   mnemonicToSeed,
   mnemonicToSeedSync,
+  mnemonicToSeedSyncFromBytes,
   mnemonicToSeedWebcrypto,
   validateMnemonic,
+  bip39ValidateMnemonicFromBytes,
+  validateMnemonicFromBytes,
 } from '../src/index.ts';
+import { wordlist as czechWordlist } from '../src/wordlists/czech.ts';
 import { wordlist as englishWordlist } from '../src/wordlists/english.ts';
+import { wordlist as frenchWordlist } from '../src/wordlists/french.ts';
+import { wordlist as italianWordlist } from '../src/wordlists/italian.ts';
 import { wordlist as japaneseWordlist } from '../src/wordlists/japanese.ts';
+import { wordlist as koreanWordlist } from '../src/wordlists/korean.ts';
 import { wordlist as portugueseWordlist } from '../src/wordlists/portuguese.ts';
+import { wordlist as simplifiedChineseWordlist } from '../src/wordlists/simplified-chinese.ts';
 import { wordlist as spanishWordlist } from '../src/wordlists/spanish.ts';
+import { wordlist as traditionalChineseWordlist } from '../src/wordlists/traditional-chinese.ts';
 import { deepStrictEqual, throws } from './assert.ts';
+
+const BYTE_PARITY_PASSPHRASE = '㍍ガバヴァぱばぐゞちぢ十人十色';
+const BYTE_PARITY_PASSPHRASE_BYTES = new TextEncoder().encode(BYTE_PARITY_PASSPHRASE);
+const BYTE_PARITY_ENTROPIES = [
+  hexToBytes('00000000000000000000000000000000'),
+  hexToBytes('4fa1a8bc3e6d80ee1316050e862c1812031493212b7ec3f3bb1b08f168cabeef'),
+];
+const BYTE_PARITY_WORDLISTS = [
+  { name: 'Czech', wordlist: czechWordlist },
+  { name: 'English', wordlist: englishWordlist },
+  { name: 'French', wordlist: frenchWordlist },
+  { name: 'Italian', wordlist: italianWordlist },
+  { name: 'Japanese', wordlist: japaneseWordlist },
+  { name: 'Korean', wordlist: koreanWordlist },
+  { name: 'Portuguese', wordlist: portugueseWordlist },
+  { name: 'Simplified Chinese', wordlist: simplifiedChineseWordlist },
+  { name: 'Spanish', wordlist: spanishWordlist },
+  { name: 'Traditional Chinese', wordlist: traditionalChineseWordlist },
+];
 
 export function equalsBytes(a: Uint8Array, b: Uint8Array): boolean {
   if (a.length !== b.length) {
@@ -137,6 +168,135 @@ describe('BIP39', () => {
           const recoveredSeedWeb = await mnemonicToSeedWebcrypto(MENMONIC, PASSPHRASE);
           deepStrictEqual(equalsBytes(SEED, recoveredSeedWeb), true);
         });
+      });
+    });
+    describe('Uint8Array inputs', () => {
+      const MENMONIC_STR = 'legal winner thank year wave sausage worth useful legal winner thank yellow';
+      const MENMONIC_BYTES = new TextEncoder().encode(MENMONIC_STR);
+      const SPANISH_MNEMONIC_STR =
+        'koala óxido urbe crudo momia idioma boina rostro títere dilema himno víspera';
+      const PORTUGUESE_MNEMONIC_STR =
+        'grunhido nevasca turbo coeso listagem galinha baronesa refugiar teclado cumprir fragata vinco';
+      const PASSPHRASE_STR = 'password';
+      const PASSPHRASE_BYTES = new TextEncoder().encode(PASSPHRASE_STR);
+      const UTF8_PASSPHRASE_STR = '㍍ガバヴァぱばぐゞちぢ十人十色';
+      const UTF8_PASSPHRASE_BYTES = new TextEncoder().encode(UTF8_PASSPHRASE_STR);
+      const JAPANESE_ENTROPY = hexToBytes('7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f');
+      const JAPANESE_MNEMONIC_STR = entropyToMnemonic(JAPANESE_ENTROPY, japaneseWordlist);
+      const JAPANESE_MNEMONIC_BYTES = new TextEncoder().encode(JAPANESE_MNEMONIC_STR);
+
+      should('work with Uint8Array mnemonic', () => {
+        // Use the new explicit byte validation function
+        deepStrictEqual(bip39ValidateMnemonicFromBytes(MENMONIC_BYTES, englishWordlist), true);
+      });
+
+      should('support the validateMnemonicFromBytes alias', () => {
+        deepStrictEqual(validateMnemonicFromBytes(MENMONIC_BYTES, englishWordlist), true);
+      });
+
+      should('recover entropy from Uint8Array mnemonic', () => {
+        const entropy1 = mnemonicToEntropy(MENMONIC_STR, englishWordlist);
+        const entropy2 = mnemonicToEntropyFromBytes(MENMONIC_BYTES, englishWordlist);
+        deepStrictEqual(entropy1, entropy2);
+      });
+
+      should('recover entropy from Spanish mnemonic bytes', () => {
+        const mnemonicBytes = new TextEncoder().encode(SPANISH_MNEMONIC_STR);
+        const entropy1 = mnemonicToEntropy(SPANISH_MNEMONIC_STR, spanishWordlist);
+        const entropy2 = mnemonicToEntropyFromBytes(mnemonicBytes, spanishWordlist);
+        deepStrictEqual(entropy1, entropy2);
+      });
+
+      should('recover entropy from Portuguese mnemonic bytes', () => {
+        const mnemonicBytes = new TextEncoder().encode(PORTUGUESE_MNEMONIC_STR);
+        const entropy1 = mnemonicToEntropy(PORTUGUESE_MNEMONIC_STR, portugueseWordlist);
+        const entropy2 = mnemonicToEntropyFromBytes(mnemonicBytes, portugueseWordlist);
+        deepStrictEqual(entropy1, entropy2);
+      });
+
+      should('recover entropy from Czech mnemonic bytes', () => {
+        const mnemonicStr = generateMnemonic(czechWordlist, 128);
+        const mnemonicBytes = new TextEncoder().encode(mnemonicStr);
+        const entropy1 = mnemonicToEntropy(mnemonicStr, czechWordlist);
+        const entropy2 = mnemonicToEntropyFromBytes(mnemonicBytes, czechWordlist);
+        deepStrictEqual(entropy1, entropy2);
+      });
+
+      should('recover entropy from Japanese mnemonic bytes', () => {
+        deepStrictEqual(
+          bytesToHex(mnemonicToEntropyFromBytes(JAPANESE_MNEMONIC_BYTES, japaneseWordlist)),
+          bytesToHex(JAPANESE_ENTROPY)
+        );
+        deepStrictEqual(
+          bip39ValidateMnemonicFromBytes(JAPANESE_MNEMONIC_BYTES, japaneseWordlist),
+          true
+        );
+      });
+
+      should('support the validateMnemonicFromBytes alias for Japanese', () => {
+        deepStrictEqual(validateMnemonicFromBytes(JAPANESE_MNEMONIC_BYTES, japaneseWordlist), true);
+      });
+
+      should('reject English mnemonic bytes with the wrong wordlist', () => {
+        deepStrictEqual(validateMnemonicFromBytes(MENMONIC_BYTES, spanishWordlist), false);
+        throws(() => mnemonicToEntropyFromBytes(MENMONIC_BYTES, spanishWordlist));
+      });
+
+      should('reject Japanese mnemonic bytes with the wrong wordlist', () => {
+        deepStrictEqual(validateMnemonicFromBytes(JAPANESE_MNEMONIC_BYTES, englishWordlist), false);
+        throws(() => mnemonicToEntropyFromBytes(JAPANESE_MNEMONIC_BYTES, englishWordlist));
+      });
+
+      should('work with Uint8Array seed derivation', async () => {
+        const seed1 = mnemonicToSeedSync(MENMONIC_STR, PASSPHRASE_STR);
+        const seed2 = mnemonicToSeedSyncFromBytes(MENMONIC_BYTES, PASSPHRASE_BYTES);
+        deepStrictEqual(seed1, seed2);
+      });
+
+      should('work with UTF-8 Uint8Array seed derivation', () => {
+        const seed1 = mnemonicToSeedSync(JAPANESE_MNEMONIC_STR, UTF8_PASSPHRASE_STR);
+        const seed2 = mnemonicToSeedSyncFromBytes(
+          JAPANESE_MNEMONIC_BYTES,
+          UTF8_PASSPHRASE_BYTES
+        );
+        deepStrictEqual(seed1, seed2);
+      });
+
+      should('generate and convert to bytes correctly', () => {
+        const mnemonicBytes = generateMnemonicBytes(englishWordlist, 128);
+        deepStrictEqual(mnemonicBytes instanceof Uint8Array, true);
+        deepStrictEqual(bip39ValidateMnemonicFromBytes(mnemonicBytes, englishWordlist), true);
+
+        const entropy = hexToBytes('7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f');
+        const expected = 'legal winner thank year wave sausage worth useful legal winner thank yellow';
+        const mBytes = entropyToMnemonicBytes(entropy, englishWordlist);
+        deepStrictEqual(new TextDecoder().decode(mBytes), expected);
+      });
+
+      should('generate Japanese mnemonic bytes correctly', () => {
+        const mnemonicBytes = generateMnemonicBytes(japaneseWordlist, 128);
+        const mnemonic = new TextDecoder().decode(mnemonicBytes);
+        deepStrictEqual(mnemonic.includes('\u3000'), true);
+        deepStrictEqual(validateMnemonicFromBytes(mnemonicBytes, japaneseWordlist), true);
+      });
+
+      should('reject mnemonic bytes with invalid word count', () => {
+        const invalidMnemonicBytes = new TextEncoder().encode(
+          'sleep kitten sleep kitten sleep kitten'
+        );
+        deepStrictEqual(validateMnemonicFromBytes(invalidMnemonicBytes, englishWordlist), false);
+        throws(() => mnemonicToEntropyFromBytes(invalidMnemonicBytes, englishWordlist));
+      });
+
+      should('reject mnemonic bytes with invalid checksum', () => {
+        const invalidMnemonicBytes = new TextEncoder().encode(
+          'legal winner thank year wave sausage worth useful legal winner thank above'
+        );
+        deepStrictEqual(
+          bip39ValidateMnemonicFromBytes(invalidMnemonicBytes, englishWordlist),
+          false
+        );
+        throws(() => mnemonicToEntropyFromBytes(invalidMnemonicBytes, englishWordlist));
       });
     });
   });
@@ -431,6 +591,27 @@ describe('BIP39', () => {
         VECTORS.japanese[i],
         i
       );
+    }
+    for (const { name, wordlist } of BYTE_PARITY_WORDLISTS) {
+      for (const entropy of BYTE_PARITY_ENTROPIES) {
+        const entropyHex = bytesToHex(entropy);
+        should(`${name} bytes/string entropy parity (${entropyHex})`, () => {
+          const mnemonic = entropyToMnemonic(entropy, wordlist);
+          const mnemonicBytes = new TextEncoder().encode(mnemonic);
+          deepStrictEqual(
+            bytesToHex(mnemonicToEntropyFromBytes(mnemonicBytes, wordlist)),
+            bytesToHex(mnemonicToEntropy(mnemonic, wordlist))
+          );
+        });
+        should(`${name} bytes/string seed parity (${entropyHex})`, () => {
+          const mnemonic = entropyToMnemonic(entropy, wordlist);
+          const mnemonicBytes = new TextEncoder().encode(mnemonic);
+          deepStrictEqual(
+            bytesToHex(mnemonicToSeedSyncFromBytes(mnemonicBytes, BYTE_PARITY_PASSPHRASE_BYTES)),
+            bytesToHex(mnemonicToSeedSync(mnemonic, BYTE_PARITY_PASSPHRASE))
+          );
+        });
+      }
     }
     should('Invalid entropy', () => {
       throws(() => entropyToMnemonic(Uint8Array.of(), englishWordlist));

--- a/test/bip39.test.ts
+++ b/test/bip39.test.ts
@@ -27,7 +27,7 @@ import { wordlist as spanishWordlist } from '../src/wordlists/spanish.ts';
 import { wordlist as traditionalChineseWordlist } from '../src/wordlists/traditional-chinese.ts';
 import { deepStrictEqual, throws } from './assert.ts';
 
-const BYTE_PARITY_PASSPHRASE = '㍍ガバヴァぱばぐゞちぢ十人十色';
+const BYTE_PARITY_PASSPHRASE = '七転び八起き、がんばりましょう';
 const BYTE_PARITY_PASSPHRASE_BYTES = new TextEncoder().encode(BYTE_PARITY_PASSPHRASE);
 const BYTE_PARITY_ENTROPIES = [
   hexToBytes('00000000000000000000000000000000'),
@@ -179,7 +179,7 @@ describe('BIP39', () => {
         'grunhido nevasca turbo coeso listagem galinha baronesa refugiar teclado cumprir fragata vinco';
       const PASSPHRASE_STR = 'password';
       const PASSPHRASE_BYTES = new TextEncoder().encode(PASSPHRASE_STR);
-      const UTF8_PASSPHRASE_STR = '㍍ガバヴァぱばぐゞちぢ十人十色';
+      const UTF8_PASSPHRASE_STR = '七転び八起き、がんばりましょう';
       const UTF8_PASSPHRASE_BYTES = new TextEncoder().encode(UTF8_PASSPHRASE_STR);
       const JAPANESE_ENTROPY = hexToBytes('7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f');
       const JAPANESE_MNEMONIC_STR = entropyToMnemonic(JAPANESE_ENTROPY, japaneseWordlist);

--- a/test/bip39.test.ts
+++ b/test/bip39.test.ts
@@ -3,17 +3,14 @@ import { describe, should } from '@paulmillr/jsbt/test.js';
 import {
   entropyToMnemonic,
   entropyToMnemonicBytes,
+  entropyToSeedSyncFromBytes,
+  generateEntropyBytes,
   generateMnemonic,
-  generateMnemonicBytes,
   mnemonicToEntropy,
-  mnemonicToEntropyFromBytes,
   mnemonicToSeed,
   mnemonicToSeedSync,
-  mnemonicToSeedSyncFromBytes,
   mnemonicToSeedWebcrypto,
   validateMnemonic,
-  bip39ValidateMnemonicFromBytes,
-  validateMnemonicFromBytes,
 } from '../src/index.ts';
 import { wordlist as czechWordlist } from '../src/wordlists/czech.ts';
 import { wordlist as englishWordlist } from '../src/wordlists/english.ts';
@@ -27,8 +24,6 @@ import { wordlist as spanishWordlist } from '../src/wordlists/spanish.ts';
 import { wordlist as traditionalChineseWordlist } from '../src/wordlists/traditional-chinese.ts';
 import { deepStrictEqual, throws } from './assert.ts';
 
-const BYTE_PARITY_PASSPHRASE = '七転び八起き、がんばりましょう';
-const BYTE_PARITY_PASSPHRASE_BYTES = new TextEncoder().encode(BYTE_PARITY_PASSPHRASE);
 const BYTE_PARITY_ENTROPIES = [
   hexToBytes('00000000000000000000000000000000'),
   hexToBytes('4fa1a8bc3e6d80ee1316050e862c1812031493212b7ec3f3bb1b08f168cabeef'),
@@ -170,133 +165,64 @@ describe('BIP39', () => {
         });
       });
     });
-    describe('Uint8Array inputs', () => {
+    describe('Uint8Array helpers', () => {
       const MENMONIC_STR = 'legal winner thank year wave sausage worth useful legal winner thank yellow';
-      const MENMONIC_BYTES = new TextEncoder().encode(MENMONIC_STR);
-      const SPANISH_MNEMONIC_STR =
-        'koala óxido urbe crudo momia idioma boina rostro títere dilema himno víspera';
-      const PORTUGUESE_MNEMONIC_STR =
-        'grunhido nevasca turbo coeso listagem galinha baronesa refugiar teclado cumprir fragata vinco';
       const PASSPHRASE_STR = 'password';
       const PASSPHRASE_BYTES = new TextEncoder().encode(PASSPHRASE_STR);
       const UTF8_PASSPHRASE_STR = '七転び八起き、がんばりましょう';
       const UTF8_PASSPHRASE_BYTES = new TextEncoder().encode(UTF8_PASSPHRASE_STR);
       const JAPANESE_ENTROPY = hexToBytes('7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f');
       const JAPANESE_MNEMONIC_STR = entropyToMnemonic(JAPANESE_ENTROPY, japaneseWordlist);
-      const JAPANESE_MNEMONIC_BYTES = new TextEncoder().encode(JAPANESE_MNEMONIC_STR);
 
-      should('work with Uint8Array mnemonic', () => {
-        // Use the new explicit byte validation function
-        deepStrictEqual(bip39ValidateMnemonicFromBytes(MENMONIC_BYTES, englishWordlist), true);
-      });
-
-      should('support the validateMnemonicFromBytes alias', () => {
-        deepStrictEqual(validateMnemonicFromBytes(MENMONIC_BYTES, englishWordlist), true);
-      });
-
-      should('recover entropy from Uint8Array mnemonic', () => {
-        const entropy1 = mnemonicToEntropy(MENMONIC_STR, englishWordlist);
-        const entropy2 = mnemonicToEntropyFromBytes(MENMONIC_BYTES, englishWordlist);
-        deepStrictEqual(entropy1, entropy2);
-      });
-
-      should('recover entropy from Spanish mnemonic bytes', () => {
-        const mnemonicBytes = new TextEncoder().encode(SPANISH_MNEMONIC_STR);
-        const entropy1 = mnemonicToEntropy(SPANISH_MNEMONIC_STR, spanishWordlist);
-        const entropy2 = mnemonicToEntropyFromBytes(mnemonicBytes, spanishWordlist);
-        deepStrictEqual(entropy1, entropy2);
-      });
-
-      should('recover entropy from Portuguese mnemonic bytes', () => {
-        const mnemonicBytes = new TextEncoder().encode(PORTUGUESE_MNEMONIC_STR);
-        const entropy1 = mnemonicToEntropy(PORTUGUESE_MNEMONIC_STR, portugueseWordlist);
-        const entropy2 = mnemonicToEntropyFromBytes(mnemonicBytes, portugueseWordlist);
-        deepStrictEqual(entropy1, entropy2);
-      });
-
-      should('recover entropy from Czech mnemonic bytes', () => {
-        const mnemonicStr = generateMnemonic(czechWordlist, 128);
-        const mnemonicBytes = new TextEncoder().encode(mnemonicStr);
-        const entropy1 = mnemonicToEntropy(mnemonicStr, czechWordlist);
-        const entropy2 = mnemonicToEntropyFromBytes(mnemonicBytes, czechWordlist);
-        deepStrictEqual(entropy1, entropy2);
-      });
-
-      should('recover entropy from Japanese mnemonic bytes', () => {
+      should('generate entropy bytes correctly', () => {
+        const entropy = generateEntropyBytes(128);
+        deepStrictEqual(entropy instanceof Uint8Array, true);
+        deepStrictEqual(entropy.length, 16);
+        const mnemonicBytes = entropyToMnemonicBytes(entropy, englishWordlist);
         deepStrictEqual(
-          bytesToHex(mnemonicToEntropyFromBytes(JAPANESE_MNEMONIC_BYTES, japaneseWordlist)),
-          bytesToHex(JAPANESE_ENTROPY)
-        );
-        deepStrictEqual(
-          bip39ValidateMnemonicFromBytes(JAPANESE_MNEMONIC_BYTES, japaneseWordlist),
+          validateMnemonic(new TextDecoder().decode(mnemonicBytes), englishWordlist),
           true
         );
       });
 
-      should('support the validateMnemonicFromBytes alias for Japanese', () => {
-        deepStrictEqual(validateMnemonicFromBytes(JAPANESE_MNEMONIC_BYTES, japaneseWordlist), true);
+      should('convert entropy to mnemonic bytes correctly', () => {
+        const entropy = hexToBytes('7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f');
+        const expected = 'legal winner thank year wave sausage worth useful legal winner thank yellow';
+        const mnemonicBytes = entropyToMnemonicBytes(entropy, englishWordlist);
+        deepStrictEqual(new TextDecoder().decode(mnemonicBytes), expected);
       });
 
-      should('reject English mnemonic bytes with the wrong wordlist', () => {
-        deepStrictEqual(validateMnemonicFromBytes(MENMONIC_BYTES, spanishWordlist), false);
-        throws(() => mnemonicToEntropyFromBytes(MENMONIC_BYTES, spanishWordlist));
+      should('convert Japanese entropy to mnemonic bytes correctly', () => {
+        const mnemonicBytes = entropyToMnemonicBytes(JAPANESE_ENTROPY, japaneseWordlist);
+        const mnemonic = new TextDecoder().decode(mnemonicBytes);
+        deepStrictEqual(mnemonic.includes('\u3000'), true);
+        deepStrictEqual(validateMnemonic(mnemonic, japaneseWordlist), true);
       });
 
-      should('reject Japanese mnemonic bytes with the wrong wordlist', () => {
-        deepStrictEqual(validateMnemonicFromBytes(JAPANESE_MNEMONIC_BYTES, englishWordlist), false);
-        throws(() => mnemonicToEntropyFromBytes(JAPANESE_MNEMONIC_BYTES, englishWordlist));
-      });
-
-      should('work with Uint8Array seed derivation', async () => {
+      should('derive seed from entropy bytes correctly', () => {
+        const entropy = mnemonicToEntropy(MENMONIC_STR, englishWordlist);
         const seed1 = mnemonicToSeedSync(MENMONIC_STR, PASSPHRASE_STR);
-        const seed2 = mnemonicToSeedSyncFromBytes(MENMONIC_BYTES, PASSPHRASE_BYTES);
+        const seed2 = entropyToSeedSyncFromBytes(entropy, englishWordlist, PASSPHRASE_BYTES);
         deepStrictEqual(seed1, seed2);
       });
 
-      should('work with UTF-8 Uint8Array seed derivation', () => {
+      should('derive seed from entropy bytes with UTF-8 passphrase correctly', () => {
         const seed1 = mnemonicToSeedSync(JAPANESE_MNEMONIC_STR, UTF8_PASSPHRASE_STR);
-        const seed2 = mnemonicToSeedSyncFromBytes(
-          JAPANESE_MNEMONIC_BYTES,
+        const seed2 = entropyToSeedSyncFromBytes(
+          JAPANESE_ENTROPY,
+          japaneseWordlist,
           UTF8_PASSPHRASE_BYTES
         );
         deepStrictEqual(seed1, seed2);
       });
 
-      should('generate and convert to bytes correctly', () => {
-        const mnemonicBytes = generateMnemonicBytes(englishWordlist, 128);
-        deepStrictEqual(mnemonicBytes instanceof Uint8Array, true);
-        deepStrictEqual(bip39ValidateMnemonicFromBytes(mnemonicBytes, englishWordlist), true);
-
-        const entropy = hexToBytes('7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f');
-        const expected = 'legal winner thank year wave sausage worth useful legal winner thank yellow';
-        const mBytes = entropyToMnemonicBytes(entropy, englishWordlist);
-        deepStrictEqual(new TextDecoder().decode(mBytes), expected);
+      should('support variable entropy length', () => {
+        deepStrictEqual(generateEntropyBytes(160).length, 20);
       });
 
-      should('generate Japanese mnemonic bytes correctly', () => {
-        const mnemonicBytes = generateMnemonicBytes(japaneseWordlist, 128);
-        const mnemonic = new TextDecoder().decode(mnemonicBytes);
-        deepStrictEqual(mnemonic.includes('\u3000'), true);
-        deepStrictEqual(validateMnemonicFromBytes(mnemonicBytes, japaneseWordlist), true);
-      });
-
-      should('reject mnemonic bytes with invalid word count', () => {
-        const invalidMnemonicBytes = new TextEncoder().encode(
-          'sleep kitten sleep kitten sleep kitten'
-        );
-        deepStrictEqual(validateMnemonicFromBytes(invalidMnemonicBytes, englishWordlist), false);
-        throws(() => mnemonicToEntropyFromBytes(invalidMnemonicBytes, englishWordlist));
-      });
-
-      should('reject mnemonic bytes with invalid checksum', () => {
-        const invalidMnemonicBytes = new TextEncoder().encode(
-          'legal winner thank year wave sausage worth useful legal winner thank above'
-        );
-        deepStrictEqual(
-          bip39ValidateMnemonicFromBytes(invalidMnemonicBytes, englishWordlist),
-          false
-        );
-        throws(() => mnemonicToEntropyFromBytes(invalidMnemonicBytes, englishWordlist));
+      should('reject invalid entropy strength', () => {
+        throws(() => generateEntropyBytes(96));
+        throws(() => generateEntropyBytes(288));
       });
     });
   });
@@ -595,21 +521,10 @@ describe('BIP39', () => {
     for (const { name, wordlist } of BYTE_PARITY_WORDLISTS) {
       for (const entropy of BYTE_PARITY_ENTROPIES) {
         const entropyHex = bytesToHex(entropy);
-        should(`${name} bytes/string entropy parity (${entropyHex})`, () => {
+        should(`${name} bytes/string mnemonic parity (${entropyHex})`, () => {
           const mnemonic = entropyToMnemonic(entropy, wordlist);
-          const mnemonicBytes = new TextEncoder().encode(mnemonic);
-          deepStrictEqual(
-            bytesToHex(mnemonicToEntropyFromBytes(mnemonicBytes, wordlist)),
-            bytesToHex(mnemonicToEntropy(mnemonic, wordlist))
-          );
-        });
-        should(`${name} bytes/string seed parity (${entropyHex})`, () => {
-          const mnemonic = entropyToMnemonic(entropy, wordlist);
-          const mnemonicBytes = new TextEncoder().encode(mnemonic);
-          deepStrictEqual(
-            bytesToHex(mnemonicToSeedSyncFromBytes(mnemonicBytes, BYTE_PARITY_PASSPHRASE_BYTES)),
-            bytesToHex(mnemonicToSeedSync(mnemonic, BYTE_PARITY_PASSPHRASE))
-          );
+          const mnemonicBytes = entropyToMnemonicBytes(entropy, wordlist);
+          deepStrictEqual(new TextDecoder().decode(mnemonicBytes), mnemonic);
         });
       }
     }

--- a/test/bip39.test.ts
+++ b/test/bip39.test.ts
@@ -11,7 +11,9 @@ import {
   mnemonicToEntropyFromBytes,
   mnemonicToSeed,
   mnemonicToSeedSync,
+  mnemonicToSeedFromBytes,
   mnemonicToSeedWebcrypto,
+  mnemonicToSeedFromBytesWebcrypto,
   validateMnemonic,
 } from '../src/index.ts';
 import { wordlist as czechWordlist } from '../src/wordlists/czech.ts';
@@ -249,6 +251,25 @@ describe('BIP39', () => {
           UTF8_PASSPHRASE_BYTES
         );
         deepStrictEqual(seed1, seed2);
+      });
+
+      should('derive seed from mnemonic bytes correctly (async)', async () => {
+        const seed1 = await mnemonicToSeed(MENMONIC_STR, PASSPHRASE_STR);
+        const seed2 = await mnemonicToSeedFromBytes(MENMONIC_BYTES, PASSPHRASE_BYTES);
+        deepStrictEqual(seed1, seed2);
+        const seed3 = await mnemonicToSeedFromBytesWebcrypto(MENMONIC_BYTES, PASSPHRASE_BYTES);
+        deepStrictEqual(seed1, seed3);
+      });
+
+      should('derive seed from Japanese mnemonic bytes correctly (async)', async () => {
+        const seed1 = await mnemonicToSeed(JAPANESE_MNEMONIC_STR, UTF8_PASSPHRASE_STR);
+        const seed2 = await mnemonicToSeedFromBytes(JAPANESE_MNEMONIC_BYTES, UTF8_PASSPHRASE_BYTES);
+        deepStrictEqual(seed1, seed2);
+        const seed3 = await mnemonicToSeedFromBytesWebcrypto(
+          JAPANESE_MNEMONIC_BYTES,
+          UTF8_PASSPHRASE_BYTES
+        );
+        deepStrictEqual(seed1, seed3);
       });
 
       should('support variable entropy length', () => {

--- a/test/bip39.test.ts
+++ b/test/bip39.test.ts
@@ -1,7 +1,7 @@
 import { bytesToHex, hexToBytes } from '@noble/hashes/utils.js';
 import { describe, should } from '@paulmillr/jsbt/test.js';
 import {
-  bip39ValidateMnemonicFromBytes,
+  validateMnemonicFromBytes,
   entropyToMnemonic,
   entropyToMnemonicBytes,
   entropyToSeedSyncFromBytes,
@@ -204,7 +204,7 @@ describe('BIP39', () => {
       });
 
       should('validate English mnemonic bytes correctly', () => {
-        deepStrictEqual(bip39ValidateMnemonicFromBytes(MENMONIC_BYTES, englishWordlist), true);
+        deepStrictEqual(validateMnemonicFromBytes(MENMONIC_BYTES, englishWordlist), true);
       });
 
       should('recover entropy from English mnemonic bytes', () => {
@@ -219,16 +219,16 @@ describe('BIP39', () => {
           bytesToHex(JAPANESE_ENTROPY)
         );
         deepStrictEqual(
-          bip39ValidateMnemonicFromBytes(JAPANESE_MNEMONIC_BYTES, japaneseWordlist),
+          validateMnemonicFromBytes(JAPANESE_MNEMONIC_BYTES, japaneseWordlist),
           true
         );
       });
 
       should('reject mnemonic bytes with the wrong wordlist', () => {
-        deepStrictEqual(bip39ValidateMnemonicFromBytes(MENMONIC_BYTES, spanishWordlist), false);
+        deepStrictEqual(validateMnemonicFromBytes(MENMONIC_BYTES, spanishWordlist), false);
         throws(() => mnemonicToEntropyFromBytes(MENMONIC_BYTES, spanishWordlist));
         deepStrictEqual(
-          bip39ValidateMnemonicFromBytes(JAPANESE_MNEMONIC_BYTES, englishWordlist),
+          validateMnemonicFromBytes(JAPANESE_MNEMONIC_BYTES, englishWordlist),
           false
         );
         throws(() => mnemonicToEntropyFromBytes(JAPANESE_MNEMONIC_BYTES, englishWordlist));

--- a/test/bip39.test.ts
+++ b/test/bip39.test.ts
@@ -15,6 +15,10 @@ import {
   mnemonicToSeedWebcrypto,
   mnemonicToSeedFromBytesWebcrypto,
   validateMnemonic,
+  equalBytes,
+  normalizeMnemonicBytes,
+  splitMnemonicBytes,
+  nfkdBytes,
 } from '../src/index.ts';
 import { wordlist as czechWordlist } from '../src/wordlists/czech.ts';
 import { wordlist as englishWordlist } from '../src/wordlists/english.ts';
@@ -664,6 +668,53 @@ describe('BIP39', () => {
         false,
         'fails for invalid checksum'
       );
+    });
+  });
+  describe('Utility functions', () => {
+    should('equalBytes should compare Uint8Arrays correctly', () => {
+      const a = new Uint8Array([1, 2, 3]);
+      const b = new Uint8Array([1, 2, 3]);
+      const c = new Uint8Array([1, 2, 4]);
+      const d = new Uint8Array([1, 2]);
+      deepStrictEqual(equalBytes(a, b), true);
+      deepStrictEqual(equalBytes(a, c), false);
+      deepStrictEqual(equalBytes(a, d), false);
+    });
+
+    should('normalizeMnemonicBytes should clean up mnemonic input', () => {
+      const input = new TextEncoder().encode('  LEGAL   winner \n THANK   year  ');
+      const expected = 'legal winner thank year';
+      const normalized = normalizeMnemonicBytes(input);
+      deepStrictEqual(new TextDecoder().decode(normalized), expected);
+      normalized.fill(0);
+    });
+
+    should('splitMnemonicBytes should split English mnemonics', () => {
+      const mnemonic = new TextEncoder().encode('abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about');
+      const words = splitMnemonicBytes(mnemonic);
+      deepStrictEqual(words.length, 12);
+    });
+
+    should('splitMnemonicBytes should handle 12 words correctly', () => {
+      const mnemonic = new TextEncoder().encode('abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about');
+      const words = splitMnemonicBytes(mnemonic);
+      deepStrictEqual(words.length, 12);
+      deepStrictEqual(new TextDecoder().decode(words[0]), 'abandon');
+      deepStrictEqual(new TextDecoder().decode(words[11]), 'about');
+    });
+
+    should('splitMnemonicBytes should handle Japanese ideographic spaces', () => {
+      const mnemonic = new TextEncoder().encode('あいこくしん　あいこくしん　あいこくしん　あいこくしん　あいこくしん　あいこくしん　あいこくしん　あいこくしん　あいこくしん　あいこくしん　あいこくしん　あおぞら');
+      const words = splitMnemonicBytes(mnemonic);
+      deepStrictEqual(words.length, 12);
+      deepStrictEqual(new TextDecoder().decode(words[0]), 'あいこくしん');
+    });
+
+    should('nfkdBytes should normalize UTF-8 bytes', () => {
+      // '㍍' (U+3312) normalizes to 'メートル' in NFKD
+      const input = new TextEncoder().encode('㍍');
+      const normalized = nfkdBytes(input);
+      deepStrictEqual(new TextDecoder().decode(normalized), 'メートル');
     });
   });
 });

--- a/test/bip39.test.ts
+++ b/test/bip39.test.ts
@@ -1,12 +1,14 @@
 import { bytesToHex, hexToBytes } from '@noble/hashes/utils.js';
 import { describe, should } from '@paulmillr/jsbt/test.js';
 import {
+  bip39ValidateMnemonicFromBytes,
   entropyToMnemonic,
   entropyToMnemonicBytes,
   entropyToSeedSyncFromBytes,
   generateEntropyBytes,
   generateMnemonic,
   mnemonicToEntropy,
+  mnemonicToEntropyFromBytes,
   mnemonicToSeed,
   mnemonicToSeedSync,
   mnemonicToSeedWebcrypto,
@@ -167,12 +169,14 @@ describe('BIP39', () => {
     });
     describe('Uint8Array helpers', () => {
       const MENMONIC_STR = 'legal winner thank year wave sausage worth useful legal winner thank yellow';
+      const MENMONIC_BYTES = new TextEncoder().encode(MENMONIC_STR);
       const PASSPHRASE_STR = 'password';
       const PASSPHRASE_BYTES = new TextEncoder().encode(PASSPHRASE_STR);
       const UTF8_PASSPHRASE_STR = '七転び八起き、がんばりましょう';
       const UTF8_PASSPHRASE_BYTES = new TextEncoder().encode(UTF8_PASSPHRASE_STR);
       const JAPANESE_ENTROPY = hexToBytes('7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f7f');
       const JAPANESE_MNEMONIC_STR = entropyToMnemonic(JAPANESE_ENTROPY, japaneseWordlist);
+      const JAPANESE_MNEMONIC_BYTES = new TextEncoder().encode(JAPANESE_MNEMONIC_STR);
 
       should('generate entropy bytes correctly', () => {
         const entropy = generateEntropyBytes(128);
@@ -197,6 +201,37 @@ describe('BIP39', () => {
         const mnemonic = new TextDecoder().decode(mnemonicBytes);
         deepStrictEqual(mnemonic.includes('\u3000'), true);
         deepStrictEqual(validateMnemonic(mnemonic, japaneseWordlist), true);
+      });
+
+      should('validate English mnemonic bytes correctly', () => {
+        deepStrictEqual(bip39ValidateMnemonicFromBytes(MENMONIC_BYTES, englishWordlist), true);
+      });
+
+      should('recover entropy from English mnemonic bytes', () => {
+        const entropy1 = mnemonicToEntropy(MENMONIC_STR, englishWordlist);
+        const entropy2 = mnemonicToEntropyFromBytes(MENMONIC_BYTES, englishWordlist);
+        deepStrictEqual(entropy1, entropy2);
+      });
+
+      should('recover entropy from Japanese mnemonic bytes', () => {
+        deepStrictEqual(
+          bytesToHex(mnemonicToEntropyFromBytes(JAPANESE_MNEMONIC_BYTES, japaneseWordlist)),
+          bytesToHex(JAPANESE_ENTROPY)
+        );
+        deepStrictEqual(
+          bip39ValidateMnemonicFromBytes(JAPANESE_MNEMONIC_BYTES, japaneseWordlist),
+          true
+        );
+      });
+
+      should('reject mnemonic bytes with the wrong wordlist', () => {
+        deepStrictEqual(bip39ValidateMnemonicFromBytes(MENMONIC_BYTES, spanishWordlist), false);
+        throws(() => mnemonicToEntropyFromBytes(MENMONIC_BYTES, spanishWordlist));
+        deepStrictEqual(
+          bip39ValidateMnemonicFromBytes(JAPANESE_MNEMONIC_BYTES, englishWordlist),
+          false
+        );
+        throws(() => mnemonicToEntropyFromBytes(JAPANESE_MNEMONIC_BYTES, englishWordlist));
       });
 
       should('derive seed from entropy bytes correctly', () => {
@@ -525,6 +560,14 @@ describe('BIP39', () => {
           const mnemonic = entropyToMnemonic(entropy, wordlist);
           const mnemonicBytes = entropyToMnemonicBytes(entropy, wordlist);
           deepStrictEqual(new TextDecoder().decode(mnemonicBytes), mnemonic);
+        });
+        should(`${name} bytes/string recovery parity (${entropyHex})`, () => {
+          const mnemonic = entropyToMnemonic(entropy, wordlist);
+          const mnemonicBytes = new TextEncoder().encode(mnemonic);
+          deepStrictEqual(
+            bytesToHex(mnemonicToEntropyFromBytes(mnemonicBytes, wordlist)),
+            bytesToHex(mnemonicToEntropy(mnemonic, wordlist))
+          );
         });
       }
     }

--- a/test/heap-scanner.test.ts
+++ b/test/heap-scanner.test.ts
@@ -1,0 +1,77 @@
+import { deepStrictEqual } from './assert.ts';
+import { describe, should } from '@paulmillr/jsbt/test.js';
+import { countSequenceInHeapStream } from './heap-scanner.ts';
+
+describe('Heap Scanner Verification', () => {
+  should('scanner should correctly identify an intentional global leak', async () => {
+    const id = Math.random().toString(36).substring(7);
+    const secret = 'LEAK_DETECT_TEST_' + id;
+    const sequence = Array.from(secret).map(c => c.charCodeAt(0));
+
+    // 1. Inject into global scope
+    (globalThis as any).EXPECTED_LEAK = secret;
+
+    // 2. Verify it's found
+    const count = await countSequenceInHeapStream(sequence);
+    deepStrictEqual(count > 0, true, 'Secret should be found in heap');
+
+    // Cleanup
+    delete (globalThis as any).EXPECTED_LEAK;
+  });
+
+  should('scanner should correctly identify an intentional Uint8Array leak', async () => {
+    const secret = 'BYTE_LEAK_TEST_123';
+    const bytes = new TextEncoder().encode(secret);
+
+    // 1. Inject as a string
+    (globalThis as any).EXPECTED_BYTE_LEAK = secret;
+
+    // 2. Verify it's found using the Uint8Array
+    const count = await countSequenceInHeapStream(bytes);
+    deepStrictEqual(count > 0, true, 'Bytes should be found in heap');
+
+    // Cleanup
+    delete (globalThis as any).EXPECTED_BYTE_LEAK;
+  });
+
+  should('scanner should correctly confirm absence after cleanup', async () => {
+    const leakAndGetSequence = () => {
+      const id = Math.random().toString(36).substring(7);
+      const secret = 'LEAK_ABSENCE_TEST_' + id;
+      (globalThis as any).TEMP_LEAK = secret;
+      return Array.from(secret).map(c => c.charCodeAt(0));
+    };
+
+    const sequence = leakAndGetSequence();
+
+    // 1. Verify it's there first
+    const countBefore = await countSequenceInHeapStream(sequence);
+    deepStrictEqual(countBefore > 0, true, 'Secret should be present initially');
+
+    // 2. Clear reference
+    (globalThis as any).TEMP_LEAK = null;
+    delete (globalThis as any).TEMP_LEAK;
+
+    // 3. Scanner should now find nothing
+    const countAfter = await countSequenceInHeapStream(sequence);
+    deepStrictEqual(countAfter === 0, true, 'Secret should be gone after cleanup');
+  });
+
+  should('scanner should correctly confirm absence after fill(0) cleanup on Uint8Array', async () => {
+    const bytes = new Uint8Array([0xde, 0xad, 0xbe, 0xef, 0x12, 0x34, 0x56, 0x78]);
+    const pattern = Array.from(bytes);
+
+    (globalThis as any).EXPECTED_BYTE_LEAK_ZERO = bytes;
+
+    // Zero out the array
+    bytes.fill(0);
+
+    // Verify it's not found
+    const count = await countSequenceInHeapStream(pattern);
+    deepStrictEqual(count === 0, true, 'Bytes should be gone after fill(0)');
+
+    delete (globalThis as any).EXPECTED_BYTE_LEAK_ZERO;
+  });
+});
+
+should.runWhen(import.meta.url);

--- a/test/heap-scanner.ts
+++ b/test/heap-scanner.ts
@@ -1,0 +1,116 @@
+import * as v8 from 'v8';
+
+/**
+ * Scans the V8 heap for a specific sequence of bytes by pulling it as a live stream.
+ * getHeapSnapshot() triggers a full Garbage Collection before taking the snapshot.
+ */
+export async function countSequenceInHeapStream(
+  sequence: number[] | Uint8Array
+): Promise<number> {
+  const snapshot = v8.getHeapSnapshot();
+
+  return new Promise((resolve, reject) => {
+    let occurrences = 0;
+
+    const bytes = Array.from(sequence);
+    const rawPattern = Buffer.from(bytes);
+    const decimalPattern = Buffer.from(bytes.join(','));
+    const hexPattern = Buffer.from(
+      bytes.map(b => b.toString(16).padStart(2, '0')).join('')
+    );
+
+    // KMP Failure Function (Partial Match Table)
+    const computeKMPTable = (pattern: Buffer): number[] => {
+      const table = new Array<number>(pattern.length).fill(0);
+      let j = 0;
+      for (let i = 1; i < pattern.length; i++) {
+        while (j > 0 && pattern[i] !== pattern[j]) {
+          j = table[j - 1];
+        }
+        if (pattern[i] === pattern[j]) {
+          j++;
+        }
+        table[i] = j;
+      }
+      return table;
+    };
+
+    const rawKMPTable = computeKMPTable(rawPattern);
+    const decimalKMPTable = computeKMPTable(decimalPattern);
+    const hexKMPTable = computeKMPTable(hexPattern);
+
+    let rawMatchIndex = 0;
+    let decimalMatchIndex = 0;
+    let hexMatchIndex = 0;
+
+    snapshot.on('data', (chunk: Buffer) => {
+      for (let i = 0; i < chunk.length; i++) {
+        const byte = chunk[i];
+
+        // Match raw using KMP
+        while (rawMatchIndex > 0 && byte !== rawPattern[rawMatchIndex]) {
+          rawMatchIndex = rawKMPTable[rawMatchIndex - 1];
+        }
+        if (byte === rawPattern[rawMatchIndex]) {
+          rawMatchIndex++;
+          if (rawMatchIndex === rawPattern.length) {
+            occurrences++;
+            rawMatchIndex = rawKMPTable[rawMatchIndex - 1];
+          }
+        }
+
+        // Match decimal using KMP
+        while (
+          decimalMatchIndex > 0 &&
+          byte !== decimalPattern[decimalMatchIndex]
+        ) {
+          decimalMatchIndex = decimalKMPTable[decimalMatchIndex - 1];
+        }
+        if (byte === decimalPattern[decimalMatchIndex]) {
+          decimalMatchIndex++;
+          if (decimalMatchIndex === decimalPattern.length) {
+            occurrences++;
+            decimalMatchIndex = decimalKMPTable[decimalMatchIndex - 1];
+          }
+        }
+
+        // Match hex using KMP
+        while (hexMatchIndex > 0 && byte !== hexPattern[hexMatchIndex]) {
+          hexMatchIndex = hexKMPTable[hexMatchIndex - 1];
+        }
+        if (byte === hexPattern[hexMatchIndex]) {
+          hexMatchIndex++;
+          if (hexMatchIndex === hexPattern.length) {
+            occurrences++;
+            hexMatchIndex = hexKMPTable[hexMatchIndex - 1];
+          }
+        }
+      }
+    });
+
+    snapshot.on('end', () => resolve(occurrences));
+    snapshot.on('error', reject);
+  });
+}
+
+/**
+ * Validates if the scanner can find a given pattern in memory.
+ */
+export async function verifyScannerFunctionality(
+  pattern: string | Uint8Array,
+  expectPresent: boolean
+): Promise<void> {
+  const sequence =
+    typeof pattern === 'string'
+      ? Array.from(pattern).map(c => c.charCodeAt(0))
+      : Array.from(pattern);
+  const count = await countSequenceInHeapStream(sequence);
+  const found = count > 0;
+
+  if (found !== expectPresent) {
+    const patternStr =
+      typeof pattern === 'string' ? pattern : `Uint8Array(${pattern.length})`;
+    const errorMsg = `Scanner Validation FAILED: Expected presence: ${expectPresent}, but found: ${found} (count: ${count}). Pattern: ${patternStr}`;
+    throw new Error(errorMsg);
+  }
+}

--- a/test/heap-scanner.ts
+++ b/test/heap-scanner.ts
@@ -7,22 +7,20 @@ import * as v8 from 'v8';
 export async function countSequenceInHeapStream(
   sequence: number[] | Uint8Array | string
 ): Promise<number> {
-  const snapshot = v8.getHeapSnapshot();
-
   return new Promise((resolve, reject) => {
     let occurrences = 0;
 
     const bytes = typeof sequence === 'string' 
       ? Array.from(sequence).map(c => c.charCodeAt(0)) 
       : Array.from(sequence);
-    const rawPattern = Buffer.from(bytes);
-    const decimalPattern = Buffer.from(bytes.join(','));
-    const hexPattern = Buffer.from(
-      bytes.map(b => b.toString(16).padStart(2, '0')).join('')
-    );
-
+    
+    // We use Uint32Array for the pattern to ensure that the secret bytes 
+    // are not stored contiguously in the JS heap (they will be padded by zeros).
+    // This prevents the scanner from finding its own search pattern.
+    const rawPattern = new Uint32Array(bytes);
+    
     // KMP Failure Function (Partial Match Table)
-    const computeKMPTable = (pattern: Buffer): number[] => {
+    const computeKMPTable = (pattern: Uint32Array): number[] => {
       const table = new Array<number>(pattern.length).fill(0);
       let j = 0;
       for (let i = 1; i < pattern.length; i++) {
@@ -36,14 +34,13 @@ export async function countSequenceInHeapStream(
       }
       return table;
     };
-
+    
     const rawKMPTable = computeKMPTable(rawPattern);
-    const decimalKMPTable = computeKMPTable(decimalPattern);
-    const hexKMPTable = computeKMPTable(hexPattern);
-
     let rawMatchIndex = 0;
-    let decimalMatchIndex = 0;
-    let hexMatchIndex = 0;
+
+    // We trigger the snapshot after preparing our patterns and tables.
+    // getHeapSnapshot triggers a full gc.
+    const snapshot = v8.getHeapSnapshot();
 
     snapshot.on('data', (chunk: Buffer) => {
       for (let i = 0; i < chunk.length; i++) {
@@ -58,33 +55,6 @@ export async function countSequenceInHeapStream(
           if (rawMatchIndex === rawPattern.length) {
             occurrences++;
             rawMatchIndex = rawKMPTable[rawMatchIndex - 1];
-          }
-        }
-
-        // Match decimal using KMP
-        while (
-          decimalMatchIndex > 0 &&
-          byte !== decimalPattern[decimalMatchIndex]
-        ) {
-          decimalMatchIndex = decimalKMPTable[decimalMatchIndex - 1];
-        }
-        if (byte === decimalPattern[decimalMatchIndex]) {
-          decimalMatchIndex++;
-          if (decimalMatchIndex === decimalPattern.length) {
-            occurrences++;
-            decimalMatchIndex = decimalKMPTable[decimalMatchIndex - 1];
-          }
-        }
-
-        // Match hex using KMP
-        while (hexMatchIndex > 0 && byte !== hexPattern[hexMatchIndex]) {
-          hexMatchIndex = hexKMPTable[hexMatchIndex - 1];
-        }
-        if (byte === hexPattern[hexMatchIndex]) {
-          hexMatchIndex++;
-          if (hexMatchIndex === hexPattern.length) {
-            occurrences++;
-            hexMatchIndex = hexKMPTable[hexMatchIndex - 1];
           }
         }
       }
@@ -112,7 +82,7 @@ export async function verifyScannerFunctionality(
   if (found !== expectPresent) {
     const patternStr =
       typeof pattern === 'string' ? pattern : `Uint8Array(${pattern.length})`;
-    const errorMsg = `Scanner Validation FAILED: Expected presence: ${expectPresent}, but found: ${found} (count: ${count}). Pattern: ${patternStr}`;
+    const errorMsg = `Scanner validation failed: Expected presence: ${expectPresent}, but found: ${found} (count: ${count}). Pattern: ${patternStr}`;
     throw new Error(errorMsg);
   }
 }

--- a/test/heap-scanner.ts
+++ b/test/heap-scanner.ts
@@ -5,14 +5,16 @@ import * as v8 from 'v8';
  * getHeapSnapshot() triggers a full Garbage Collection before taking the snapshot.
  */
 export async function countSequenceInHeapStream(
-  sequence: number[] | Uint8Array
+  sequence: number[] | Uint8Array | string
 ): Promise<number> {
   const snapshot = v8.getHeapSnapshot();
 
   return new Promise((resolve, reject) => {
     let occurrences = 0;
 
-    const bytes = Array.from(sequence);
+    const bytes = typeof sequence === 'string' 
+      ? Array.from(sequence).map(c => c.charCodeAt(0)) 
+      : Array.from(sequence);
     const rawPattern = Buffer.from(bytes);
     const decimalPattern = Buffer.from(bytes.join(','));
     const hexPattern = Buffer.from(

--- a/test/heap.test.ts
+++ b/test/heap.test.ts
@@ -1,83 +1,34 @@
-import { describe, should } from '@paulmillr/jsbt/test.js';
 import { deepStrictEqual } from './assert.ts';
+import { describe, should } from '@paulmillr/jsbt/test.js';
 import { countSequenceInHeapStream } from './heap-scanner.ts';
+import { validateMnemonic, validateMnemonicFromBytes } from '../src/index.ts';
+import { wordlist } from '../wordlists/english.js';
 
-/**
- * Heap Scanner Validation Test (libqc)
- *
- * This test ensures that our memory scanner is functional in the Node.js environment.
- */
-describe('Heap Scanner Verification', () => {
-  should('correctly identify an intentional global leak in Node.js', async () => {
-    const id = Math.random().toString(36).substring(7);
-    const secret = 'LEAK_DETECT_TEST_' + id;
-    const sequence = Array.from(secret).map(c => c.charCodeAt(0));
+describe('Mnemonic Memory Security Audit', () => {
+  // This test suite demonstrates that JavaScript Strings (immutable) 
+  // persist in the V8 heap even after they are no longer needed, 
+  // as they cannot be explicitly zeroed or cleared.
 
-    // 1. Inject into global scope
-    (global as any).EXPECTED_LEAK = secret;
+  should('String Validation API: demonstrates that strings PERSIST in memory after use', async () => {
+    // 1. Define mnemonic as a string literal. 
+    // Literals are interned and persist in the V8 heap indefinitely.
+    const MNEMONIC = 'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
+    let mnemonicString = MNEMONIC;
 
-    // 2. Verify it's found
-    const count = await countSequenceInHeapStream(sequence);
-    deepStrictEqual(count > 0, true);
+    // 2. Verify it is present in the heap initially
+    const countBefore = await countSequenceInHeapStream(MNEMONIC);
+    deepStrictEqual(countBefore > 0, true, 'Mnemonic string should be found in heap initially');
 
-    // Cleanup
-    delete (global as any).EXPECTED_LEAK;
-  });
+    // 3. Validate using the string-based API
+    const isValid = validateMnemonic(mnemonicString, wordlist);
+    deepStrictEqual(isValid, true, 'Mnemonic should be valid');
 
-  should('correctly identify an intentional Uint8Array leak in Node.js', async () => {
-    const secret = 'BYTE_LEAK_TEST_123';
-    const bytes = new TextEncoder().encode(secret);
+    // 4. Assigning to empty string doesn't zero the original memory (immutable strings)
+    mnemonicString = "";
 
-    // 1. Inject as a string
-    (global as any).EXPECTED_BYTE_LEAK = secret;
-
-    // 2. Verify it's found using the Uint8Array
-    const count = await countSequenceInHeapStream(bytes);
-    deepStrictEqual(count > 0, true);
-
-    // Cleanup
-    delete (global as any).EXPECTED_BYTE_LEAK;
-  });
-
-  should('correctly confirm absence after cleanup', async () => {
-    // Helper to avoid keeping the secret string in the local stack of the test function
-    const leakAndGetSequence = () => {
-      const id = Math.random().toString(36).substring(7);
-      const secret = 'LEAK_ABSENCE_TEST_' + id;
-      (global as any).TEMP_LEAK = secret;
-      return Array.from(secret).map(c => c.charCodeAt(0));
-    };
-
-    const sequence = leakAndGetSequence();
-
-    // 1. Verify it's there first
-    const countBefore = await countSequenceInHeapStream(sequence);
-    deepStrictEqual(countBefore > 0, true);
-
-    // 2. Clear reference
-    (global as any).TEMP_LEAK = null;
-    delete (global as any).TEMP_LEAK;
-
-    // 3. Scanner should now find nothing
-    const countAfter = await countSequenceInHeapStream(sequence);
-
-    deepStrictEqual(countAfter, 0);
-  });
-
-  should('correctly confirm absence after fill(0) cleanup on Uint8Array', async () => {
-    const bytes = new Uint8Array([0xde, 0xad, 0xbe, 0xef, 0x12, 0x34, 0x56, 0x78]);
-    const pattern = Array.from(bytes);
-
-    (global as any).EXPECTED_BYTE_LEAK_ZERO = bytes;
-
-    // Zero out the array
-    bytes.fill(0);
-
-    // Verify it's not found
-    const count = await countSequenceInHeapStream(pattern);
-    deepStrictEqual(count, 0);
-
-    delete (global as any).EXPECTED_BYTE_LEAK_ZERO;
+    // 5. Count after - it persists because we cannot clear it manually
+    const countAfter = await countSequenceInHeapStream(MNEMONIC);
+    deepStrictEqual(countAfter > 0, true, 'Mnemonic string should STILL be found in heap after validation (leaked)');
   });
 });
 

--- a/test/heap.test.ts
+++ b/test/heap.test.ts
@@ -1,10 +1,10 @@
 import { deepStrictEqual } from './assert.ts';
 import { describe, should } from '@paulmillr/jsbt/test.js';
 import { countSequenceInHeapStream } from './heap-scanner.ts';
-import { validateMnemonic, validateMnemonicFromBytes } from '../src/index.ts';
+import { validateMnemonic, validateMnemonicFromBytes, entropyToMnemonicBytes, generateEntropyBytes } from '../src/index.ts';
 import { wordlist } from '../src/wordlists/english.ts';
 
-describe('Mnemonic Memory Security Audit', () => {
+describe('Mnemonic Memory Security Checks', () => {
   // This test suite demonstrates that JavaScript Strings (immutable) 
   // persist in the V8 heap even after they are no longer needed, 
   // as they cannot be explicitly zeroed or cleared.
@@ -33,15 +33,9 @@ describe('Mnemonic Memory Security Audit', () => {
 
   should('Byte-based API: demonstrates that memory can be explicitly cleared', async () => {
     // 1. Create mnemonic as Uint8Array (mutable)
-    // We use a different phrase than the string test and define it via bytes
-    // to avoid creating a string literal that would be interned in the heap.
-    // Phrase: 'legal winner thank year wave sausage worth useful legal winner thank yellow'
-    const mnemonic = new Uint8Array([
-      108, 101, 103, 97, 108, 32, 119, 105, 110, 110, 101, 114, 32, 116, 104, 97, 110, 107, 32, 121,
-      101, 97, 114, 32, 119, 97, 118, 101, 32, 115, 97, 117, 115, 97, 103, 101, 32, 119, 111, 114,
-      116, 104, 32, 117, 115, 101, 102, 117, 108, 32, 108, 101, 103, 97, 108, 32, 119, 105, 110,
-      110, 101, 114, 32, 116, 104, 97, 110, 107, 32, 121, 101, 108, 108, 111, 119
-    ]);
+    // We generate it randomly to ensure it's not in any source code constants.
+    const entropy = generateEntropyBytes(128);
+    const mnemonic = entropyToMnemonicBytes(entropy, wordlist);
 
     // 2. Validate using the byte-based API
     const isValid = validateMnemonicFromBytes(mnemonic, wordlist);
@@ -68,7 +62,7 @@ describe('Mnemonic Memory Security Audit', () => {
 
     // 4. Verify that the sensitive data never leaked to the V8 heap.
     // Unlike strings, byte-based mnemonics live in a separate memory area (Buffer/ArrayBuffer).
-    // This check ensures that the validation process did not leave any traces on the JS heap.
+    // This check ensures that the validation process did not leave any traces on the js heap.
     const countAfter = await countSequenceInHeapStream(pattern);
     deepStrictEqual(countAfter === 0, true, 'Mnemonic content should never leak to the V8 heap');
   });

--- a/test/heap.test.ts
+++ b/test/heap.test.ts
@@ -1,0 +1,84 @@
+import { describe, should } from '@paulmillr/jsbt/test.js';
+import { deepStrictEqual } from './assert.ts';
+import { countSequenceInHeapStream } from './heap-scanner.ts';
+
+/**
+ * Heap Scanner Validation Test (libqc)
+ *
+ * This test ensures that our memory scanner is functional in the Node.js environment.
+ */
+describe('Heap Scanner Verification', () => {
+  should('correctly identify an intentional global leak in Node.js', async () => {
+    const id = Math.random().toString(36).substring(7);
+    const secret = 'LEAK_DETECT_TEST_' + id;
+    const sequence = Array.from(secret).map(c => c.charCodeAt(0));
+
+    // 1. Inject into global scope
+    (global as any).EXPECTED_LEAK = secret;
+
+    // 2. Verify it's found
+    const count = await countSequenceInHeapStream(sequence);
+    deepStrictEqual(count > 0, true);
+
+    // Cleanup
+    delete (global as any).EXPECTED_LEAK;
+  });
+
+  should('correctly identify an intentional Uint8Array leak in Node.js', async () => {
+    const secret = 'BYTE_LEAK_TEST_123';
+    const bytes = new TextEncoder().encode(secret);
+
+    // 1. Inject as a string
+    (global as any).EXPECTED_BYTE_LEAK = secret;
+
+    // 2. Verify it's found using the Uint8Array
+    const count = await countSequenceInHeapStream(bytes);
+    deepStrictEqual(count > 0, true);
+
+    // Cleanup
+    delete (global as any).EXPECTED_BYTE_LEAK;
+  });
+
+  should('correctly confirm absence after cleanup', async () => {
+    // Helper to avoid keeping the secret string in the local stack of the test function
+    const leakAndGetSequence = () => {
+      const id = Math.random().toString(36).substring(7);
+      const secret = 'LEAK_ABSENCE_TEST_' + id;
+      (global as any).TEMP_LEAK = secret;
+      return Array.from(secret).map(c => c.charCodeAt(0));
+    };
+
+    const sequence = leakAndGetSequence();
+
+    // 1. Verify it's there first
+    const countBefore = await countSequenceInHeapStream(sequence);
+    deepStrictEqual(countBefore > 0, true);
+
+    // 2. Clear reference
+    (global as any).TEMP_LEAK = null;
+    delete (global as any).TEMP_LEAK;
+
+    // 3. Scanner should now find nothing
+    const countAfter = await countSequenceInHeapStream(sequence);
+
+    deepStrictEqual(countAfter, 0);
+  });
+
+  should('correctly confirm absence after fill(0) cleanup on Uint8Array', async () => {
+    const bytes = new Uint8Array([0xde, 0xad, 0xbe, 0xef, 0x12, 0x34, 0x56, 0x78]);
+    const pattern = Array.from(bytes);
+
+    (global as any).EXPECTED_BYTE_LEAK_ZERO = bytes;
+
+    // Zero out the array
+    bytes.fill(0);
+
+    // Verify it's not found
+    const count = await countSequenceInHeapStream(pattern);
+    deepStrictEqual(count, 0);
+
+    delete (global as any).EXPECTED_BYTE_LEAK_ZERO;
+  });
+});
+
+should.runWhen(import.meta.url);

--- a/test/heap.test.ts
+++ b/test/heap.test.ts
@@ -47,6 +47,7 @@ describe('Mnemonic Memory Security Audit', () => {
     const isValid = validateMnemonicFromBytes(mnemonic, wordlist);
     deepStrictEqual(isValid, true, 'Mnemonic should be valid');
 
+    // Copy pattern before zeroing
     const pattern = Array.from(mnemonic);
 
     // 3. Explicitly zero the memory

--- a/test/heap.test.ts
+++ b/test/heap.test.ts
@@ -2,7 +2,7 @@ import { deepStrictEqual } from './assert.ts';
 import { describe, should } from '@paulmillr/jsbt/test.js';
 import { countSequenceInHeapStream } from './heap-scanner.ts';
 import { validateMnemonic, validateMnemonicFromBytes } from '../src/index.ts';
-import { wordlist } from '../wordlists/english.js';
+import { wordlist } from '../src/wordlists/english.ts';
 
 describe('Mnemonic Memory Security Audit', () => {
   // This test suite demonstrates that JavaScript Strings (immutable) 

--- a/test/heap.test.ts
+++ b/test/heap.test.ts
@@ -9,7 +9,7 @@ describe('Mnemonic Memory Security Audit', () => {
   // persist in the V8 heap even after they are no longer needed, 
   // as they cannot be explicitly zeroed or cleared.
 
-  should('String Validation API: demonstrates that strings PERSIST in memory after use', async () => {
+  should('String Validation API: demonstrates that strings persist in memory after use', async () => {
     // 1. Define mnemonic as a string literal. 
     // Literals are interned and persist in the V8 heap indefinitely.
     const MNEMONIC = 'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
@@ -28,7 +28,48 @@ describe('Mnemonic Memory Security Audit', () => {
 
     // 5. Count after - it persists because we cannot clear it manually
     const countAfter = await countSequenceInHeapStream(MNEMONIC);
-    deepStrictEqual(countAfter > 0, true, 'Mnemonic string should STILL be found in heap after validation (leaked)');
+    deepStrictEqual(countAfter > 0, true, 'Mnemonic string should still be found in heap after validation (leaked)');
+  });
+
+  should('Byte-based API: demonstrates that memory can be explicitly cleared', async () => {
+    // 1. Create mnemonic as Uint8Array (mutable)
+    // We use a different phrase than the string test and define it via bytes
+    // to avoid creating a string literal that would be interned in the heap.
+    // Phrase: 'legal winner thank year wave sausage worth useful legal winner thank yellow'
+    const mnemonic = new Uint8Array([
+      108, 101, 103, 97, 108, 32, 119, 105, 110, 110, 101, 114, 32, 116, 104, 97, 110, 107, 32, 121,
+      101, 97, 114, 32, 119, 97, 118, 101, 32, 115, 97, 117, 115, 97, 103, 101, 32, 119, 111, 114,
+      116, 104, 32, 117, 115, 101, 102, 117, 108, 32, 108, 101, 103, 97, 108, 32, 119, 105, 110,
+      110, 101, 114, 32, 116, 104, 97, 110, 107, 32, 121, 101, 108, 108, 111, 119
+    ]);
+
+    // 2. Validate using the byte-based API
+    const isValid = validateMnemonicFromBytes(mnemonic, wordlist);
+    deepStrictEqual(isValid, true, 'Mnemonic should be valid');
+
+    const pattern = Array.from(mnemonic);
+
+    // 3. Explicitly zero the memory
+    // We also verify the buffer content manually to prove it's zeroed.
+    deepStrictEqual(mnemonic.some(b => b !== 0), true, 'Buffer should contain data before zeroing');
+
+    let fillCalled = false;
+    const originalFill = mnemonic.fill;
+    mnemonic.fill = function (value: number) {
+      fillCalled = true;
+      return originalFill.apply(this, [value] as any);
+    };
+
+    mnemonic.fill(0);
+
+    deepStrictEqual(fillCalled, true, 'mnemonic.fill(0) should have been called');
+    deepStrictEqual(mnemonic.every(b => b === 0), true, 'Buffer should be physically all zeros');
+
+    // 4. Verify that the sensitive data never leaked to the V8 heap.
+    // Unlike strings, byte-based mnemonics live in a separate memory area (Buffer/ArrayBuffer).
+    // This check ensures that the validation process did not leave any traces on the JS heap.
+    const countAfter = await countSequenceInHeapStream(pattern);
+    deepStrictEqual(countAfter === 0, true, 'Mnemonic content should never leak to the V8 heap');
   });
 });
 

--- a/test/index.ts
+++ b/test/index.ts
@@ -1,3 +1,4 @@
 import { it } from '@paulmillr/jsbt/test.js';
 import './bip39.test.ts';
+import './heap.test.ts';
 it.runWhen(import.meta.url);

--- a/test/index.ts
+++ b/test/index.ts
@@ -1,4 +1,5 @@
 import { it } from '@paulmillr/jsbt/test.js';
 import './bip39.test.ts';
 import './heap.test.ts';
+import './heap-scanner.test.ts';
 it.runWhen(import.meta.url);


### PR DESCRIPTION
## Why

This PR adds byte-oriented BIP-39 helpers to improve control over sensitive data lifetime in memory. Using `Uint8Array` does not eliminate all temporary string creation on Unicode paths, but it gives callers mutable buffers that can be zeroed after use, unlike immutable JavaScript strings.

## How

The change adds byte-based APIs for mnemonic generation, entropy conversion, validation, and sync seed derivation, while keeping behavior aligned with the existing string-based APIs. It also improves the docs for the new exports and adds compact parity tests that verify byte/string equivalence across all supported wordlists, including Japanese and both Chinese variants.

## Security / Environment Variables

This change is security-motivated in the sense that it improves caller control over zeroing sensitive data in memory. It adds no new dependencies, no external integrations, and no new environment variables.

## Testing

Test coverage was expanded with granular `Uint8Array` cases and loop-based byte/string parity checks for all supported languages. Verified with `pnpm test` and `pnpm build` in `scure-bip39`.